### PR TITLE
Feat/config BlockBuilder로 파싱및 block 생성

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,11 @@ SRCS = main.cpp \
 			 HttpDirective.cpp \
 			 ServerDirective.cpp \
 			 LocationDirective.cpp \
-			 Parse.cpp \
 			 Server.cpp \
 			 ServerBlock.cpp \
-			 util.cpp 
+			 util.cpp \
+			 BlockBuilder.cpp \
+			 Parse.cpp \
 
 INC = include
 

--- a/include/BlockBuilder.hpp
+++ b/include/BlockBuilder.hpp
@@ -59,6 +59,7 @@ class BlockBuilder
     ServerBlock buildServerBlock() const;
     LocationBlock buildLocationBlock() const;
     void resetServerBlockConfig();
+    void resetLocationBlockConfig();
 };
 
 #endif // BLOCKBUILDER_HPP

--- a/include/BlockBuilder.hpp
+++ b/include/BlockBuilder.hpp
@@ -48,7 +48,8 @@ class BlockBuilder
     HttpDirective mHttpDirective;
     ServerDirective mServerDirective;
     LocationDirective mLocationDirective;
-    void updateConfig(const std::string &key, const std::string &value, bool isFirstValue);
+    void updateConfig(const std::string &key, const std::string &value, bool isFirstValue, bool &isFirstIndex,
+                      bool &isFirstErrorPage);
     std::string reduceMultipleSpaces(std::string token);
     unsigned int convertNumber(const std::string &valueString, bool hasUnit);
 

--- a/include/BlockBuilder.hpp
+++ b/include/BlockBuilder.hpp
@@ -1,0 +1,64 @@
+#ifndef BLOCKBUILDER_HPP
+#define BLOCKBUILDER_HPP
+
+#include "HttpBlock.hpp"
+#include "HttpDirective.hpp"
+#include "LocationBlock.hpp"
+#include "LocationDirective.hpp"
+#include "ServerBlock.hpp"
+#include "ServerDirective.hpp"
+#include <string>
+#include <vector>
+
+enum unit
+{
+    killo = 1000,
+    mega = 1000000,
+    giga = 100000000,
+};
+enum blockType
+{
+    Http,
+    Server,
+    Location,
+};
+class BlockBuilder
+{
+
+  private:
+    std::string mRoot;
+    std::vector<std::string> mIndexs;
+    // todo : errorpage를 어떻게 받을것인가
+    // 예시 :  500 502 503 504 /50x.html; 또는 error_page  404 /404.html;
+    std::vector<std::string> mErrorPages;
+    unsigned int mClientMaxBodySize;
+
+    unsigned int mPort;
+    std::string mServerName;
+    unsigned int mRedirectionCode;
+    std::string mRedirectionPath;
+
+    std::string mLocationPath;
+    bool mIsAutoIndex;
+    bool mIsAllowedGet;
+    bool mIsAllowedPost;
+    bool mIsAllowedDelete;
+
+    bool mIsMethodAllowed;
+    HttpDirective mHttpDirective;
+    ServerDirective mServerDirective;
+    LocationDirective mLocationDirective;
+    void updateConfig(const std::string &key, const std::string &value, bool isFirstValue);
+    std::string reduceMultipleSpaces(std::string token);
+    unsigned int convertNumber(const std::string &valueString, bool hasUnit);
+
+  public:
+    BlockBuilder();
+    void parseConfig(const enum blockType, const std::string &configStr);
+    HttpBlock buildHttpBlock() const;
+    ServerBlock buildServerBlock() const;
+    LocationBlock buildLocationBlock() const;
+    void resetServerBlockConfig();
+};
+
+#endif // BLOCKBUILDER_HPP

--- a/include/Config.hpp
+++ b/include/Config.hpp
@@ -1,26 +1,16 @@
 #ifndef CONFIG_HPP
 #define CONFIG_HPP
 
-#include "ADirective.hpp"
+#include "BlockBuilder.hpp"
 #include "HttpBlock.hpp"
-#include "HttpDirective.hpp"
 #include "LocationBlock.hpp"
-#include "LocationDirective.hpp"
 #include "ServerBlock.hpp"
-#include "ServerDirective.hpp"
 #include <cassert>
 #include <fstream>
 #include <iostream>
 #include <map>
 #include <sstream>
 #include <vector>
-
-enum unit
-{
-    killo = 1000,
-    mega = 1000000,
-    giga = 100000000,
-};
 
 typedef std::vector<std::string> LocationVec;
 typedef std::pair<std::string, LocationVec> ServerLocPair;
@@ -33,28 +23,19 @@ class Config
     Config();
     Config &operator=(const Config &rhs);
     // clang-format off
-    Config(HttpBlock httpBlock, std::vector<std::pair<ServerBlock, std::vector<LocationBlock> > > mServerBlockGroups);
+    Config(std::vector<std::pair<ServerBlock, std::vector<LocationBlock> > > mServerBlockGroups);
+		static std::vector<std::pair<ServerBlock, std::vector<LocationBlock> > > mServerBlockGroups;
     // clang-format on
 
     static Config *mInstance;
-    static HttpBlock mHttpBlock;
-    std::vector<ServerWithLocations> ServerList;
-    // clang-format off
-    //std::vector<std::pair<ServerBlock, std::vector<LocationBlock> > > mServerBlockGroups;
-    // clang-format on
-    static HttpBlock createHttpBlock(std::string httpStr);
-    static ServerWithLocations createServerWithLocations(HttpBlock httpBlock, ServerLocPair serverLocPair);
-    static LocationBlock createLocationBlock(ServerBlock serverBlock, std::string locationStr);
-    static std::string reduceMultipleSpaces(std::string token);
-    static unsigned int convertNumber(std::string &valueString, bool hasUnit);
 
   public:
-    // ~Config();
     // clang-format off
-    static void createInstance(std::string httpString);
-                                 //std::vector<std::pair<std::string, std::vector<std::string> > > mServerStr);
+    static void createInstance(std::string httpString, std::vector<std::pair<std::string, std::vector<std::string> > > mServerStr);
     // clang-format on
     static Config &getInstance();
     static void deleteInstance(); // 새로운 config를 만들고 싶을때?
+
+    static const std::vector<ServerWithLocations> &getServerBlockGroups();
 };
 #endif

--- a/include/LocationBlock.hpp
+++ b/include/LocationBlock.hpp
@@ -22,6 +22,7 @@ class LocationBlock : public ServerBlock
     LocationBlock(ServerBlock serverBlock, std::string locationPath, bool isAutoIndex, bool isAllowedGet,
                   bool isAllowedPost, bool isAllowedDelete);
     LocationBlock &operator=(const LocationBlock &rhs);
+    friend std::ostream &operator<<(std::ostream &os, LocationBlock &locationBlock);
 };
 
 #endif

--- a/include/LocationDirective.hpp
+++ b/include/LocationDirective.hpp
@@ -5,10 +5,8 @@
 
 class LocationDirective : public ADirective
 {
-  protected:
-    virtual void initDirectiveMap();
-
   public:
     LocationDirective();
+    virtual void initDirectiveMap();
 };
 #endif

--- a/include/Parse.hpp
+++ b/include/Parse.hpp
@@ -28,7 +28,8 @@ class Parse
   public:
     Parse(const char *path);
     ~Parse();
-    void test();
+    const std::string &getHttpStr() const;
+    const std::vector<ServerLocPair> &getServerLocPairs() const;
 };
 
 #endif

--- a/include/ServerBlock.hpp
+++ b/include/ServerBlock.hpp
@@ -11,14 +11,6 @@ class ServerBlock : public HttpBlock
     // listen의 중복을 허용하지 않고 port로 받음
 
   protected:
-    // return은 http redirection에 사용하는 지시어
-    // 보통  location /old-path {
-    //     return 301 /new-path;
-    // 어디까지 들어올수 있나..
-    // 301
-    // }
-    // 301(영구 이동)나 302(임시 이동)
-    // 이런식으로 쓰임
     unsigned int mPort;
     // server_name도 중복이 되지만 허용 안하는것으로
     std::string mServerName;
@@ -30,6 +22,7 @@ class ServerBlock : public HttpBlock
                 std::string redirectionPath);
     ServerBlock(const ServerBlock &other);
     ServerBlock &operator=(const ServerBlock &rhs);
+    friend std::ostream &operator<<(std::ostream &os, ServerBlock &serverBlock);
 };
 
 #endif

--- a/include/ServerDirective.hpp
+++ b/include/ServerDirective.hpp
@@ -5,10 +5,8 @@
 
 class ServerDirective : public ADirective
 {
-  protected:
-    virtual void initDirectiveMap();
-
   public:
     ServerDirective();
+    virtual void initDirectiveMap();
 };
 #endif

--- a/src/ADirective.cpp
+++ b/src/ADirective.cpp
@@ -3,14 +3,18 @@
 void ADirective::checkDirective(const std::string &str)
 {
     std::map<std::string, int>::iterator it;
+
     it = mDirective.find(str);
     if (it != mDirective.end())
     {
         if (it->second == 0)
         {
-            throw std::runtime_error("duplicate");
+            throw std::runtime_error("Error : ADirective::checkDirective() 지시어 중복\n" + str);
         }
         --it->second;
     }
-    throw std::runtime_error("지시어 없음");
+    else
+    {
+        throw std::runtime_error("Error : ADirective::checkDirective() 지시어 없음\n" + str);
+    }
 }

--- a/src/BlockBuilder.cpp
+++ b/src/BlockBuilder.cpp
@@ -3,8 +3,8 @@
 #include <sstream>
 
 BlockBuilder::BlockBuilder()
-    : mRoot("html"), mClientMaxBodySize(1000000), mPort(80), mServerName(""), mRedirectionCode(42), mIsAutoIndex(false),
-      mIsAllowedGet(true), mIsAllowedPost(true), mIsAllowedDelete(true)
+    : mRoot("html"), mClientMaxBodySize(1000000), mPort(80), mServerName(""), mRedirectionCode(200),
+      mIsAutoIndex(false), mIsAllowedGet(true), mIsAllowedPost(true), mIsAllowedDelete(true)
 {
     mIndexs.push_back("index.html");
 }
@@ -273,8 +273,16 @@ void BlockBuilder::resetServerBlockConfig()
 {
     mPort = 80;
     mServerName = "";
-    mRedirectionCode = 42;
+    mRedirectionCode = 200;
     mRedirectionPath.clear();
+}
+
+void BlockBuilder::resetLocationBlockConfig()
+{
+    mIsAutoIndex = false;
+    mIsAllowedGet = true;
+    mIsAllowedPost = true;
+    mIsAllowedDelete = true;
 }
 
 HttpBlock BlockBuilder::buildHttpBlock() const

--- a/src/BlockBuilder.cpp
+++ b/src/BlockBuilder.cpp
@@ -1,0 +1,294 @@
+#include "BlockBuilder.hpp"
+#include <iostream>
+#include <sstream>
+
+BlockBuilder::BlockBuilder()
+    : mRoot("html"), mClientMaxBodySize(1000000), mPort(80), mServerName(""), mRedirectionCode(42), mIsAutoIndex(false),
+      mIsAllowedGet(true), mIsAllowedPost(true), mIsAllowedDelete(true)
+{
+    mIndexs.push_back("index.html");
+}
+
+std::string BlockBuilder::reduceMultipleSpaces(std::string token)
+{
+    std::string cleanedToken;
+    bool previousWasSpace = false;
+    char c;
+    for (std::size_t i = 0; i < token.size(); ++i)
+    {
+        c = token[i];
+        if (c != ' ' && c != '\t')
+        {
+            cleanedToken += c;
+            previousWasSpace = false;
+        }
+        else
+        {
+            if (!previousWasSpace)
+            {
+                cleanedToken += ' ';
+            }
+            previousWasSpace = true;
+        }
+    }
+    return cleanedToken;
+}
+
+unsigned int BlockBuilder::convertNumber(const std::string &valueString, bool hasUnit)
+{
+    char *checkPtr;
+    int value;
+
+    value = std::strtod(valueString.c_str(), &checkPtr);
+    if (value < 0)
+    {
+        throw std::runtime_error(std::to_string(value) + ": invalid max_body_size1");
+    }
+    else if (value == 0 && *checkPtr != '\0')
+    {
+        throw std::runtime_error(valueString + ": invalid max_body_size2");
+    }
+
+    if (hasUnit == true)
+    {
+        switch (*checkPtr)
+        {
+        case 'k':
+            // 의도적인 fallthrough
+        case 'K':
+            value *= killo;
+            break;
+        case 'm':
+            // 의도적인 fallthrough
+        case 'M':
+            value *= mega;
+            break;
+        case 'g':
+            // 의도적인 fallthrough
+        case 'G':
+            value *= giga;
+            break;
+        case '\0':
+            break;
+        default:
+            throw std::runtime_error(valueString + ": invalid max_body_size3");
+            break;
+        }
+        if (*checkPtr != '\0' && *(checkPtr + 1) != '\0')
+        {
+            throw std::runtime_error(valueString + ": invalid max_body_size4");
+        }
+    }
+    else
+    {
+        if (*checkPtr != '\0')
+        {
+            throw std::runtime_error(valueString + ": invalid Value");
+        }
+    }
+    return static_cast<unsigned int>(value);
+}
+
+void BlockBuilder::parseConfig(const enum blockType blockType, const std::string &configString)
+{
+
+    std::istringstream iss(configString);
+    std::string token;
+    mServerDirective.initDirectiveMap();
+    mLocationDirective.initDirectiveMap();
+
+    while (std::getline(iss, token, ';'))
+    {
+        std::istringstream tokenStream(reduceMultipleSpaces(token));
+        std::string subtoken;
+        std::string keyValue;
+        bool isKeyValue = true;
+        bool isValue = false;
+        bool isFirstValue = true;
+        while (tokenStream >> subtoken)
+        {
+            if (isKeyValue == true)
+            {
+                if (blockType == Http)
+                {
+                    mHttpDirective.checkDirective(subtoken);
+                }
+                else if (blockType == Server)
+                {
+                    mServerDirective.checkDirective(subtoken);
+                }
+                else if (blockType == Location)
+                {
+                    mLocationDirective.checkDirective(subtoken);
+                }
+                isKeyValue = false;
+                keyValue = subtoken;
+                continue;
+            }
+            updateConfig(keyValue, subtoken, isFirstValue);
+            isValue = true;
+            isFirstValue = false;
+        }
+        if (tokenStream.fail())
+        {
+            if (isValue == false)
+            {
+                throw std::runtime_error("Error: BlockBuilder::parseConfig() no value\n" + subtoken);
+            }
+        }
+    }
+}
+
+void BlockBuilder::updateConfig(const std::string &key, const std::string &value, bool isFirstValue)
+{
+    if (key == "root")
+    {
+        mRoot = value;
+    }
+    else if (key == "index")
+    {
+        if (isFirstValue == true)
+        {
+            mIndexs.clear();
+        }
+        mIndexs.push_back(value);
+    }
+    else if (key == "error_page")
+    {
+        if (isFirstValue == true)
+        {
+            mErrorPages.clear();
+        }
+        mErrorPages.push_back(value);
+    }
+    else if (key == "client_max_body_size")
+    {
+        mClientMaxBodySize = convertNumber(value, true);
+    }
+    else if (key == "server_name")
+    {
+        mServerName = value;
+    }
+    else if (key == "return")
+    {
+        if (isFirstValue == true)
+        {
+            mRedirectionCode = convertNumber(value, false);
+        }
+        else
+        {
+            mRedirectionPath = value;
+        }
+    }
+    else if (key == "listen")
+    {
+        mPort = convertNumber(value, false);
+    }
+    else if (key == "path")
+    {
+        mLocationPath = value;
+    }
+    else if (key == "autoindex")
+    {
+        if (value == "on")
+        {
+            mIsAutoIndex = true;
+        }
+        else if (value == "off")
+        {
+            mIsAutoIndex = false;
+        }
+        else
+        {
+            throw std::runtime_error("Error BlockBuilder::updateConfig() : invalid value in \"autoindex\"\n" + value);
+        }
+    }
+    else if (key == "limit_except")
+    {
+        if (isFirstValue == true)
+        {
+            if (value == "allow")
+            {
+                mIsMethodAllowed = true;
+            }
+            else if (value == "deny")
+            {
+                mIsMethodAllowed = false;
+            }
+            else
+            {
+                throw std::runtime_error("Error BlockBuilder::updateConfig() : invalid access in \"limit_except\"\n" +
+                                         value);
+            }
+        }
+        else
+        {
+            if (value == "GET")
+            {
+                if (mIsMethodAllowed == true)
+                {
+                    mIsAllowedGet = true;
+                }
+                else
+                {
+                    mIsAllowedGet = false;
+                }
+            }
+            else if (value == "POST")
+            {
+                if (mIsMethodAllowed == true)
+                {
+                    mIsAllowedPost = true;
+                }
+                else
+                {
+                    mIsAllowedPost = false;
+                }
+            }
+            else if (value == "DELETE")
+            {
+                if (mIsMethodAllowed == true)
+                {
+                    mIsAllowedDelete = true;
+                }
+                else
+                {
+                    mIsAllowedDelete = false;
+                }
+            }
+            else
+            {
+                throw std::runtime_error("Error BlockBuilder::updateConfig() : invalid method in \"limit_except\"\n" +
+                                         value);
+            }
+        }
+    }
+    else
+    {
+        assert(false);
+    }
+}
+
+void BlockBuilder::resetServerBlockConfig()
+{
+    mPort = 80;
+    mServerName = "";
+    mRedirectionCode = 42;
+    mRedirectionPath.clear();
+}
+
+HttpBlock BlockBuilder::buildHttpBlock() const
+{
+    return HttpBlock(mRoot, mIndexs, mErrorPages, mClientMaxBodySize);
+}
+
+ServerBlock BlockBuilder::buildServerBlock() const
+{
+    return ServerBlock(buildHttpBlock(), mPort, mServerName, mRedirectionCode, mRedirectionPath);
+}
+
+LocationBlock BlockBuilder::buildLocationBlock() const
+{
+    return LocationBlock(buildServerBlock(), mLocationPath, mIsAutoIndex, mIsAllowedGet, mIsAllowedPost,
+                         mIsAllowedDelete);
+}

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -31,6 +31,7 @@ Config::Config(std::vector<std::pair<ServerBlock, std::vector<LocationBlock> > >
         std::vector<LocationBlock> locationBlocks;
         for (size_t j = 0; j < locationStrings.size(); ++j)
         {
+            builder.resetLocationBlockConfig();
             builder.parseConfig(Location, locationStrings[j]);
             LocationBlock locationBlock = builder.buildLocationBlock();
             // 디버그용 print

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -1,22 +1,45 @@
 #include "Config.hpp"
 
-Config *Config::mInstance = NULL; // Definition of mInstance
+Config *Config::mInstance = NULL;                            // Definition of mInstance
+std::vector<ServerWithLocations> Config::mServerBlockGroups; // Definition of ServerBlockGroups
 
 // clang-format off
-//Config::Config(HttpBlock httpBlock, std::vector<std::pair<ServerBlock, std::vector<LocationBlock> > > mServerBlockGroups)
-//{
-//	
-//}
-// clang-format on
-
-// clang-format off
-void Config::createInstance(std::string httpString)
-                                 //std::vector<std::pair<std::string, std::vector<std::string> > > mServerStr)
+Config::Config(std::vector<std::pair<ServerBlock, std::vector<LocationBlock> > > serverBlockGroups)
 // clang-format on
 {
-    HttpBlock httpBlock = createHttpBlock(httpString);
-    std::cout << httpBlock;
-    // mInstance = new Config(httpBlock);
+    mServerBlockGroups = serverBlockGroups;
+}
+
+// clang-format off
+	void Config::createInstance(std::string httpString, std::vector<std::pair<std::string, std::vector<std::string> > > mServerStr)
+// clang-format on
+{
+    BlockBuilder builder;
+    builder.parseConfig(Http, httpString);
+
+    for (size_t i = 0; i < mServerStr.size(); ++i)
+    {
+        builder.resetServerBlockConfig();
+        const std::string &serverString = mServerStr[i].first;
+        const std::vector<std::string> &locationStrings = mServerStr[i].second;
+
+        builder.parseConfig(Server, serverString);
+        ServerBlock serverBlock = builder.buildServerBlock();
+        // 디버그용 print
+        std::cout << "server : " << std::endl << serverBlock << std::endl;
+
+        std::vector<LocationBlock> locationBlocks;
+        for (size_t j = 0; j < locationStrings.size(); ++j)
+        {
+            builder.parseConfig(Location, locationStrings[j]);
+            LocationBlock locationBlock = builder.buildLocationBlock();
+            // 디버그용 print
+            std::cout << "location :" << std::endl << locationBlock << std::endl;
+            locationBlocks.push_back(locationBlock);
+        }
+        mServerBlockGroups.push_back(std::make_pair(serverBlock, locationBlocks));
+    }
+    mInstance = new Config(mServerBlockGroups);
 }
 
 Config &Config::getInstance()
@@ -38,295 +61,7 @@ void Config::deleteInstance()
     mInstance = NULL;
 }
 
-std::string Config::reduceMultipleSpaces(std::string token)
+const std::vector<ServerWithLocations> &Config::getServerBlockGroups()
 {
-    std::string cleanedToken;
-    bool previousWasSpace = false;
-    char c;
-    for (std::size_t i = 0; i < token.size(); ++i)
-    {
-        c = token[i];
-        if (c != ' ' && c != '\t')
-        {
-            cleanedToken += c;
-            previousWasSpace = false;
-        }
-        else
-        {
-            if (!previousWasSpace)
-            {
-                cleanedToken += ' ';
-            }
-            previousWasSpace = true;
-        }
-    }
-    return cleanedToken;
-}
-
-unsigned int Config::convertNumber(std::string &valueString, bool hasUnit)
-{
-    char *checkPtr;
-    int value;
-
-    value = std::strtod(valueString.c_str(), &checkPtr);
-    if (value < 0)
-    {
-        throw std::runtime_error(std::to_string(value) + ": invalid max_body_size1");
-    }
-    else if (value == 0 && checkPtr != '\0')
-    {
-        throw std::runtime_error(valueString + ": invalid max_body_size2");
-    }
-
-    if (hasUnit == true)
-    {
-        switch (*checkPtr)
-        {
-        case 'k':
-            // 의도적인 fallthrough
-        case 'K':
-            value *= killo;
-            break;
-        case 'm':
-            // 의도적인 fallthrough
-        case 'M':
-            value *= mega;
-            break;
-        case 'g':
-            // 의도적인 fallthrough
-        case 'G':
-            value *= giga;
-            break;
-        case '\0':
-            break;
-        default:
-            throw std::runtime_error(valueString + ": invalid max_body_size3");
-            break;
-        }
-        if (*checkPtr != '\0' && *(checkPtr + 1) != '\0')
-        {
-            throw std::runtime_error(valueString + ": invalid max_body_size4");
-        }
-    }
-    else
-    {
-        if (*checkPtr != '\0')
-        {
-            throw std::runtime_error(valueString + ": invalid Value");
-        }
-    }
-    return static_cast<unsigned int>(value);
-}
-
-HttpBlock Config::createHttpBlock(std::string httpStr)
-{
-    // root 기본값 html, index index.html, errorpage ""(없음), client_max_body_size = 1m;
-    std::istringstream iss(httpStr);
-    std::string token;
-    std::string root = "html";
-    std::vector<std::string> indexs;
-    std::vector<std::string> errorPages;
-    unsigned int clientMaxBodySize = 1000000;
-    HttpDirective h;
-
-    while (std::getline(iss, token, ';'))
-    {
-        std::istringstream tokenStream(reduceMultipleSpaces(token));
-        std::string subtoken;
-        std::string keyValue;
-        bool isKeyValue = true;
-        bool isValue = false;
-        while (tokenStream >> subtoken)
-        {
-            if (isKeyValue == true)
-            {
-                h.checkDirective(subtoken);
-                isKeyValue = false;
-                keyValue = subtoken;
-                continue;
-            }
-
-            if (keyValue == "root")
-            {
-                root = subtoken;
-            }
-            else if (keyValue == "index")
-            {
-                indexs.push_back(subtoken);
-            }
-            else if (keyValue == "error_page")
-            {
-                errorPages.push_back(subtoken);
-            }
-            else
-            {
-                clientMaxBodySize = convertNumber(subtoken, true);
-            }
-            isValue = true;
-        }
-        if (tokenStream.fail())
-        {
-            if (isValue == false)
-            {
-                throw std::runtime_error("no value");
-            }
-        }
-    }
-    // indexs 값이 안 들어왔을때 기본값
-    if (indexs.size() == 0)
-    {
-        indexs.push_back("index.html");
-    }
-
-    return HttpBlock(root, indexs, errorPages, clientMaxBodySize);
-}
-
-// LocationBlock Config::createLocationBlock(ServerBlock serverBlock, std::string locationStr)
-// {
-//     LocationDirective locationDirective;
-//     assert(locationStr.size() != 0);
-
-//     // 서버 블록 만들기 인데 httpBlock이 필요하겠네?
-//     std::istringstream iss(locationStr);
-//     std::string mLocationPath;
-//     bool mIsAutoIndex = false;
-//     bool mIsAllowedGet = true;
-//     bool mIsAllowedPost = true;
-//     bool mIsAllowedDelete = true;
-//     std::string token;
-
-//     // /hi;
-//     while (std::getline(iss, token, ';'))
-//     {
-//         std::istringstream tokenStream(reduceMultipleSpaces(token));
-//         std::string subtoken;
-//         std::string keyValue;
-//         bool isKeyValue = true;
-//         bool isValue = false;
-//         while (tokenStream >> subtoken)
-//         {
-//             if (isKeyValue == true)
-//             {
-//                 locationDirective.checkDirective(subtoken);
-//                 isKeyValue = false;
-//                 keyValue = subtoken;
-//                 continue;
-//             }
-
-//             if (keyValue == "server_name")
-//             {
-//                 serverName = subtoken;
-//             }
-//             else if (keyValue == "return")
-//             {
-//                 if (isRedirectionCode == true)
-//                 {
-//                     redirectionCode = convertNumber(subtoken, false);
-//                     isRedirectionCode = false;
-//                 }
-//                 else
-//                 {
-//                     redirectionPath = subtoken;
-//                 }
-//             }
-//             else
-//             {
-//                 port = convertNumber(subtoken, false);
-//             }
-//             isValue = true;
-//         }
-//         if (tokenStream.fail())
-//         {
-//             if (isValue == false)
-//             {
-//                 throw std::runtime_error("no value");
-//             }
-//         }
-//     }
-// }
-
-ServerWithLocations Config::createServerWithLocations(HttpBlock httpBlock,
-                                                      std::pair<std::string, LocationVec> serverLocPair)
-{
-    std::string serverString;
-    ServerDirective serverDirective;
-    serverString = serverLocPair.first;
-    assert(serverString.size() != 0);
-
-    // 서버 블록 만들기 인데 httpBlock이 필요하겠네?
-    std::istringstream iss(serverString);
-    unsigned int port = 80;
-    std::string serverName = "";
-    unsigned int redirectionCode;
-    std::string redirectionPath;
-    std::string token;
-
-    while (std::getline(iss, token, ';'))
-    {
-        std::istringstream tokenStream(reduceMultipleSpaces(token));
-        std::string subtoken;
-        std::string keyValue;
-        bool isKeyValue = true;
-        bool isValue = false;
-        bool isRedirectionCode = true;
-        // return 301 /hi2
-        // subtoken return
-        // tokenStream 301 /hi2
-        while (tokenStream >> subtoken)
-        {
-            if (isKeyValue == true)
-            {
-                serverDirective.checkDirective(subtoken);
-                isKeyValue = false;
-                keyValue = subtoken;
-                continue;
-            }
-
-            if (keyValue == "server_name")
-            {
-                serverName = subtoken;
-            }
-            else if (keyValue == "return")
-            {
-                if (isRedirectionCode == true)
-                {
-                    redirectionCode = convertNumber(subtoken, false);
-                    isRedirectionCode = false;
-                }
-                else
-                {
-                    redirectionPath = subtoken;
-                }
-            }
-            else
-            {
-                port = convertNumber(subtoken, false);
-            }
-            isValue = true;
-        }
-        if (tokenStream.fail())
-        {
-            if (isValue == false)
-            {
-                throw std::runtime_error("no value");
-            }
-        }
-    }
-
-    ServerBlock serverBlock(httpBlock, port, serverName, redirectionCode, redirectionPath);
-
-    std::vector<LocationBlock> locations;
-    std::vector<std::string> locationStrs = serverLocPair.second;
-    std::vector<std::string>::iterator it = locationStrs.begin();
-
-    // location 돌면서 다 만들기. 함수로 빼도 가능
-    for (; it != locationStrs.end(); ++it)
-    {
-        // 함수가 돌아버린다
-        // 반환값이 locationBlock
-        // 이걸 locations에 pushback
-    }
-    std::pair<ServerBlock, LocationList> tmp = std::make_pair(serverBlock, locations);
-
-    return tmp;
+    return mServerBlockGroups;
 }

--- a/src/LocationBlock.cpp
+++ b/src/LocationBlock.cpp
@@ -33,6 +33,7 @@ LocationBlock &LocationBlock::operator=(const LocationBlock &rhs)
 
 std::ostream &operator<<(std::ostream &os, LocationBlock &locationBlock)
 {
+    os << "LocationPath : " << locationBlock.mLocationPath << std::endl;
     os << "root : " << locationBlock.mRoot << std::endl;
 
     std::vector<std::string>::iterator it = locationBlock.mIndexs.begin();
@@ -59,7 +60,6 @@ std::ostream &operator<<(std::ostream &os, LocationBlock &locationBlock)
     os << "redirectionCode : " << locationBlock.mRedirectionCode << "    ";
     os << "redirectionPath : " << locationBlock.mRedirectionPath << std::endl;
 
-    os << "LocationPath : " << locationBlock.mLocationPath << std::endl;
     os << "isAutoIndex : " << std::boolalpha << locationBlock.mIsAutoIndex << std::endl;
     os << "isAllowedGet: " << std::boolalpha << locationBlock.mIsAllowedGet << std::endl;
     os << "isAllowedPost : " << std::boolalpha << locationBlock.mIsAllowedPost << std::endl;

--- a/src/LocationBlock.cpp
+++ b/src/LocationBlock.cpp
@@ -30,3 +30,39 @@ LocationBlock &LocationBlock::operator=(const LocationBlock &rhs)
     }
     return *this;
 }
+
+std::ostream &operator<<(std::ostream &os, LocationBlock &locationBlock)
+{
+    os << "root : " << locationBlock.mRoot << std::endl;
+
+    std::vector<std::string>::iterator it = locationBlock.mIndexs.begin();
+
+    os << "index : ";
+    for (; it != locationBlock.mIndexs.end(); ++it)
+    {
+        os << *it << " ";
+    }
+    os << std::endl;
+
+    os << "errorPages : ";
+    it = locationBlock.mErrorPages.begin();
+    for (; it != locationBlock.mErrorPages.end(); ++it)
+    {
+        os << *it << " ";
+    }
+    os << std::endl;
+
+    os << "clientMaxBodySize : " << locationBlock.mClientMaxBodySize << std::endl;
+
+    os << "port : " << locationBlock.mPort << std::endl;
+    os << "serverName : " << locationBlock.mServerName << std::endl;
+    os << "redirectionCode : " << locationBlock.mRedirectionCode << "    ";
+    os << "redirectionPath : " << locationBlock.mRedirectionPath << std::endl;
+
+    os << "LocationPath : " << locationBlock.mLocationPath << std::endl;
+    os << "isAutoIndex : " << std::boolalpha << locationBlock.mIsAutoIndex << std::endl;
+    os << "isAllowedGet: " << std::boolalpha << locationBlock.mIsAllowedGet << std::endl;
+    os << "isAllowedPost : " << std::boolalpha << locationBlock.mIsAllowedPost << std::endl;
+    os << "isAllowedDelete : " << std::boolalpha << locationBlock.mIsAllowedDelete << std::endl;
+    return os;
+}

--- a/src/LocationDirective.cpp
+++ b/src/LocationDirective.cpp
@@ -7,6 +7,8 @@ LocationDirective::LocationDirective() : ADirective()
 
 void LocationDirective::initDirectiveMap()
 {
+    // location /hi 면 /hi가 path
+    mDirective["path"] = 1;
     mDirective["root"] = 1;
     mDirective["index"] = std::numeric_limits<int>::max();
     mDirective["error_page"] = std::numeric_limits<int>::max();

--- a/src/Parse.cpp
+++ b/src/Parse.cpp
@@ -206,24 +206,22 @@ std::string Parse::storeLocationStr(std::string &line)
         if (line[0] == '}')
         {
             checkCloseBrace(line);
-            return locationStr;
+            break;
         }
         else
         {
             parseElseLine(locationStr, line);
         }
     }
+    return locationStr;
 }
 
-void Parse::test()
+const std::string &Parse::getHttpStr() const
 {
-    std::cout << "http 스트링:" << mHttpStr << std::endl;
-    for (auto tmp : mServerLocPairs)
-    {
-        std::cout << "server 스트링:" << tmp.first << std::endl;
-        for (auto tmp2 : tmp.second)
-        {
-            std::cout << "location 스트링:" << tmp2 << std::endl;
-        }
-    }
+    return mHttpStr;
+}
+
+const std::vector<Parse::ServerLocPair> &Parse::getServerLocPairs() const
+{
+    return mServerLocPairs;
 }

--- a/src/Parse.cpp
+++ b/src/Parse.cpp
@@ -67,12 +67,12 @@ void Parse::checkLocationPath(std::string &line, std::string &locationStr)
         {
             throw std::runtime_error("Error Parse::checkLocationPath(): Location Path가 없습니다.");
         }
-        locationStr += tmp + ";";
+        locationStr += "path " + tmp + ";";
         line = line.substr(pos);
     }
     else
     {
-        locationStr += line + ";";
+        locationStr += "path " + line + ";";
         ftGetLine(mFile, line);
     }
 }

--- a/src/Parse.cpp
+++ b/src/Parse.cpp
@@ -172,6 +172,7 @@ void Parse::storeServerStr(std::string &line)
         {
             checkCloseBrace(line);
             mServerLocPairs.push_back(std::make_pair(serverStr, locationStrVec));
+            return;
         }
         else if (line.find("location") == 0)
         {

--- a/src/ServerBlock.cpp
+++ b/src/ServerBlock.cpp
@@ -33,3 +33,34 @@ ServerBlock &ServerBlock::operator=(const ServerBlock &rhs)
     }
     return *this;
 }
+
+std::ostream &operator<<(std::ostream &os, ServerBlock &serverBlock)
+{
+    os << "root : " << serverBlock.mRoot << std::endl;
+
+    std::vector<std::string>::iterator it = serverBlock.mIndexs.begin();
+
+    os << "index : ";
+    for (; it != serverBlock.mIndexs.end(); ++it)
+    {
+        os << *it << " ";
+    }
+    os << std::endl;
+
+    os << "errorPages : ";
+    it = serverBlock.mErrorPages.begin();
+    for (; it != serverBlock.mErrorPages.end(); ++it)
+    {
+        os << *it << " ";
+    }
+    os << std::endl;
+
+    os << "clientMaxBodySize : " << serverBlock.mClientMaxBodySize << std::endl;
+
+    os << "port : " << serverBlock.mPort << std::endl;
+    os << "serverName : " << serverBlock.mServerName << std::endl;
+    os << "redirectionCode : " << serverBlock.mRedirectionCode << "    ";
+    os << "redirectionPath : " << serverBlock.mRedirectionPath << std::endl;
+
+    return os;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,5 +7,6 @@
 int main()
 {
     Parse a("www/a.conf");
+    std::cout << "serverStr : " << a.getHttpStr() << std::endl;
     Config::createInstance(a.getHttpStr(), a.getServerLocPairs());
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,11 @@
+#include "BlockBuilder.hpp"
 #include "Config.hpp"
 #include "LocationBlock.hpp"
+#include "Parse.hpp"
 #include "ServerBlock.hpp"
+
+int main()
+{
+    Parse a("www/a.conf");
+    Config::createInstance(a.getHttpStr(), a.getServerLocPairs());
+}

--- a/www/a.conf
+++ b/www/a.conf
@@ -1,22 +1,28 @@
 http {
+	root a;
   #include    conf/mime.types;
-  index    index.html index.htm index.php;
+  index    a;
+
 
   server { # main server
+		error_page 303;
     listen       80; ##port(server name 먼저 확인), IP+port(요청 IP와 port대조), IP(default port)
     server_name  localhost; ## 요청 host header와 일치하는 서버네임, 선행 와일드카드, 후행 와일드카드, 정규식, 기본서버
     root         wwww;
 
-	location / {
+	location  / {
+  	error_page 404 /404.html;
+		index b;
 		limit_except deny GET;
 		limit_except deny POST;
-
 	  }
+
 	location /files/ {
+		index c;
          root /var/www/html/files;
          autoindex on;
+				 index cc;
       }
-  }
-
-  error_page 404 /404.html
+	}
+	index d;
 }

--- a/www/a.conf
+++ b/www/a.conf
@@ -1,49 +1,22 @@
-http 
+http {
+  #include    conf/mime.types;
+  index    index.html index.htm index.php;
 
+  server { # main server
+    listen       80; ##port(server name 먼저 확인), IP+port(요청 IP와 port대조), IP(default port)
+    server_name  localhost; ## 요청 host header와 일치하는 서버네임, 선행 와일드카드, 후행 와일드카드, 정규식, 기본서버
+    root         wwww;
 
-{ 
+	location / {
+		limit_except deny GET;
+		limit_except deny POST;
 
-	server 
-	
-	
-	{
-		listen 		 
-		8080;
+	  }
+	location /files/ {
+         root /var/www/html/files;
+         autoindex on;
+      }
+  }
 
-
-
-		server_name  localhost;
-
-
-
-        location /
-				
-				
-				{
-            root html;
-            index  index.html index.htm;
-        }
-
-				error_page 500 502 503 504  /50x.html;
-        location  /50x.html {
-            root 
-						 
-						 
-						 
-						 html;
-        }
-
-
-
-    }
-
-
-
-
-
-
-
-
-
-
-} 
+  error_page 404 /404.html
+}

--- a/www/a.conf
+++ b/www/a.conf
@@ -1,0 +1,49 @@
+http 
+
+
+{ 
+
+	server 
+	
+	
+	{
+		listen 		 
+		8080;
+
+
+
+		server_name  localhost;
+
+
+
+        location /
+				
+				
+				{
+            root html;
+            index  index.html index.htm;
+        }
+
+				error_page 500 502 503 504  /50x.html;
+        location  /50x.html {
+            root 
+						 
+						 
+						 
+						 html;
+        }
+
+
+
+    }
+
+
+
+
+
+
+
+
+
+
+} 


### PR DESCRIPTION
### Summary
- BlockBuilder 클래스를 완성하고 에러메세지를 통일했습니다.
- BlockBuilder 클래스에 대한 이야기는 http_block, server_block, location_block 상속 문제  #12  를 참고 부탁드립니다.
### Description
- Config에서 HttpStr, ServerStr, LocationStr를 파싱하고 std::vector<std::pair<ServerBlock, std::vector >>>
- mServerBlockGroups을 만드는 과정을 BlockBuilder 클래스를 만들어서 config의 역할을 나눴습니다.
- BlockBuilder
- BlockBuilder.parseConfig(enum(Http, Server, Location)과 string)을 받아서 BlockBuilder의 내부 변수로 parse된 값을 들고 있습니다.
- BlockBuilder.buildHttpBlock()등을 만들어서 block클래스들을 반환합니다.
- 이렇게 파싱과 class을 만드는 과정을 쪼개서 위의 이슈를 해결했습니다.
- 부가적으로 동일한 로직의 파싱도 합쳤습니다.

### TODO
- errorPage가 애매해서 일단 벡터로 pushback만 해놓은 상태입니다.
- cgi은 아직 이해가 안돼서 나중에 locationBlock의 매개변수 locationDirective의 init 함수의 수정이 필요합니다.