### PR TITLE
feat: ServerInfo클래스 생성, block마다 getter 생성, BlockBuild 논리 수정

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ SRCS = main.cpp \
 			 util.cpp \
 			 BlockBuilder.cpp \
 			 Parse.cpp \
+			 ServerInfo.cpp \
 
 INC = include
 

--- a/include/BlockBuilder.hpp
+++ b/include/BlockBuilder.hpp
@@ -59,8 +59,8 @@ class BlockBuilder
     HttpBlock buildHttpBlock() const;
     ServerBlock buildServerBlock() const;
     LocationBlock buildLocationBlock() const;
-    void resetServerBlockConfig();
-    void resetLocationBlockConfig();
+    void resetServerBlockConfig(const HttpBlock &httpBlock);
+    void resetLocationBlockConfig(const ServerBlock &serverBLock);
 };
 
 #endif // BLOCKBUILDER_HPP

--- a/include/Config.hpp
+++ b/include/Config.hpp
@@ -5,6 +5,7 @@
 #include "HttpBlock.hpp"
 #include "LocationBlock.hpp"
 #include "ServerBlock.hpp"
+#include "ServerInfo.hpp"
 #include <cassert>
 #include <fstream>
 #include <iostream>
@@ -14,8 +15,6 @@
 
 typedef std::vector<std::string> LocationVec;
 typedef std::pair<std::string, LocationVec> ServerLocPair;
-typedef std::vector<LocationBlock> LocationList;
-typedef std::pair<ServerBlock, LocationList> ServerWithLocations;
 
 class Config
 {
@@ -23,10 +22,11 @@ class Config
     Config();
     Config &operator=(const Config &rhs);
     // clang-format off
-    Config(std::vector<std::pair<ServerBlock, std::vector<LocationBlock> > > mServerBlockGroups);
-		static std::vector<std::pair<ServerBlock, std::vector<LocationBlock> > > mServerBlockGroups;
+    Config(std::vector<ServerInfo> serverInfos);
+		static std::vector<ServerInfo> mServerInfos;
+    // Config(std::vector<std::pair<ServerBlock, std::vector<LocationBlock> > > mServerBlockGroups);
+		// static std::vector<std::pair<ServerBlock, std::vector<LocationBlock> > > mServerBlockGroups;
     // clang-format on
-
     static Config *mInstance;
 
   public:
@@ -35,7 +35,6 @@ class Config
     // clang-format on
     static Config &getInstance();
     static void deleteInstance(); // 새로운 config를 만들고 싶을때?
-
-    static const std::vector<ServerWithLocations> &getServerBlockGroups();
+    static const std::vector<ServerInfo> &getServerInfos();
 };
 #endif

--- a/include/HttpBlock.hpp
+++ b/include/HttpBlock.hpp
@@ -26,8 +26,13 @@ class HttpBlock
               unsigned int clientMaxBodySize);
     HttpBlock(const HttpBlock &other);
     HttpBlock &operator=(const HttpBlock &rhs);
+
+    const std::string &getRoot() const;
+    const std::vector<std::string> &getIndexs() const;
+    const std::vector<std::string> &getErrorPages() const;
+    unsigned int getClientMaxBodySize() const;
     // todo : friend 없애야함
-    friend std::ostream &operator<<(std::ostream &os, HttpBlock &httpBlock);
+    friend std::ostream &operator<<(std::ostream &os, const HttpBlock &httpBlock);
 };
 
 #endif

--- a/include/LocationBlock.hpp
+++ b/include/LocationBlock.hpp
@@ -22,7 +22,7 @@ class LocationBlock : public ServerBlock
     LocationBlock(ServerBlock serverBlock, std::string locationPath, bool isAutoIndex, bool isAllowedGet,
                   bool isAllowedPost, bool isAllowedDelete);
     LocationBlock &operator=(const LocationBlock &rhs);
-    friend std::ostream &operator<<(std::ostream &os, LocationBlock &locationBlock);
+    friend std::ostream &operator<<(std::ostream &os, const LocationBlock &locationBlock);
 };
 
 #endif

--- a/include/ServerBlock.hpp
+++ b/include/ServerBlock.hpp
@@ -22,7 +22,11 @@ class ServerBlock : public HttpBlock
                 std::string redirectionPath);
     ServerBlock(const ServerBlock &other);
     ServerBlock &operator=(const ServerBlock &rhs);
-    friend std::ostream &operator<<(std::ostream &os, ServerBlock &serverBlock);
+    unsigned int getPort() const;
+    const std::string &getServerName() const;
+    unsigned int getRedirectionCode() const;
+    const std::string &getRedirectionPath() const;
+    friend std::ostream &operator<<(std::ostream &os, const ServerBlock &serverBlock);
 };
 
 #endif

--- a/include/ServerInfo.hpp
+++ b/include/ServerInfo.hpp
@@ -1,0 +1,20 @@
+#ifndef SERVERINFO_HPP
+#define SERVERINFO_HPP
+
+#include "LocationBlock.hpp"
+#include "ServerBlock.hpp"
+
+class ServerInfo
+{
+  private:
+    ServerBlock mServerBlock;
+    std::vector<LocationBlock> mLocationBlocks;
+
+  public:
+    ServerInfo(const ServerBlock &serverBlock, const std::vector<LocationBlock> &locationBlocks);
+    const ServerBlock &getServerBlock() const;
+    const std::vector<LocationBlock> &getLocationBlocks() const;
+
+    friend std::ostream &operator<<(std::ostream &os, const ServerInfo &serverInfo);
+};
+#endif

--- a/src/BlockBuilder.cpp
+++ b/src/BlockBuilder.cpp
@@ -277,16 +277,28 @@ void BlockBuilder::updateConfig(const std::string &key, const std::string &value
     }
 }
 
-void BlockBuilder::resetServerBlockConfig()
+void BlockBuilder::resetServerBlockConfig(const HttpBlock &httpBlock)
 {
+    mRoot = httpBlock.getRoot();
+    mIndexs = httpBlock.getIndexs();
+    mErrorPages = httpBlock.getErrorPages();
+    mClientMaxBodySize = httpBlock.getClientMaxBodySize();
     mPort = 80;
     mServerName = "";
     mRedirectionCode = 200;
     mRedirectionPath.clear();
 }
 
-void BlockBuilder::resetLocationBlockConfig()
+void BlockBuilder::resetLocationBlockConfig(const ServerBlock &serverBlock)
 {
+    mRoot = serverBlock.getRoot();
+    mIndexs = serverBlock.getIndexs();
+    mErrorPages = serverBlock.getErrorPages();
+    mClientMaxBodySize = serverBlock.getClientMaxBodySize();
+    mPort = serverBlock.getPort();
+    mServerName = serverBlock.getServerName();
+    mRedirectionCode = serverBlock.getRedirectionCode();
+    mRedirectionPath = serverBlock.getRedirectionPath();
     mIsAutoIndex = false;
     mIsAllowedGet = true;
     mIsAllowedPost = true;

--- a/src/HttpBlock.cpp
+++ b/src/HttpBlock.cpp
@@ -27,11 +27,31 @@ HttpBlock &HttpBlock::operator=(const HttpBlock &rhs)
     return *this;
 }
 
-std::ostream &operator<<(std::ostream &os, HttpBlock &httpBlock)
+const std::string &HttpBlock::getRoot() const
+{
+    return mRoot;
+}
+
+const std::vector<std::string> &HttpBlock::getIndexs() const
+{
+    return mIndexs;
+}
+
+const std::vector<std::string> &HttpBlock::getErrorPages() const
+{
+    return mErrorPages;
+}
+
+unsigned int HttpBlock::getClientMaxBodySize() const
+{
+    return mClientMaxBodySize;
+}
+
+std::ostream &operator<<(std::ostream &os, const HttpBlock &httpBlock)
 {
     os << "root : " << httpBlock.mRoot << std::endl;
 
-    std::vector<std::string>::iterator it = httpBlock.mIndexs.begin();
+    std::vector<std::string>::const_iterator it = httpBlock.mIndexs.begin();
 
     os << "index : ";
     for (; it != httpBlock.mIndexs.end(); ++it)

--- a/src/LocationBlock.cpp
+++ b/src/LocationBlock.cpp
@@ -31,12 +31,12 @@ LocationBlock &LocationBlock::operator=(const LocationBlock &rhs)
     return *this;
 }
 
-std::ostream &operator<<(std::ostream &os, LocationBlock &locationBlock)
+std::ostream &operator<<(std::ostream &os, const LocationBlock &locationBlock)
 {
     os << "LocationPath : " << locationBlock.mLocationPath << std::endl;
     os << "root : " << locationBlock.mRoot << std::endl;
 
-    std::vector<std::string>::iterator it = locationBlock.mIndexs.begin();
+    std::vector<std::string>::const_iterator it = locationBlock.mIndexs.begin();
 
     os << "index : ";
     for (; it != locationBlock.mIndexs.end(); ++it)

--- a/src/ServerBlock.cpp
+++ b/src/ServerBlock.cpp
@@ -34,11 +34,31 @@ ServerBlock &ServerBlock::operator=(const ServerBlock &rhs)
     return *this;
 }
 
-std::ostream &operator<<(std::ostream &os, ServerBlock &serverBlock)
+unsigned int ServerBlock::getPort() const
+{
+    return mPort;
+}
+
+const std::string &ServerBlock::getServerName() const
+{
+    return mServerName;
+}
+
+unsigned int ServerBlock::getRedirectionCode() const
+{
+    return mRedirectionCode;
+}
+
+const std::string &ServerBlock::getRedirectionPath() const
+{
+    return mRedirectionPath;
+}
+
+std::ostream &operator<<(std::ostream &os, const ServerBlock &serverBlock)
 {
     os << "root : " << serverBlock.mRoot << std::endl;
 
-    std::vector<std::string>::iterator it = serverBlock.mIndexs.begin();
+    std::vector<std::string>::const_iterator it = serverBlock.mIndexs.begin();
 
     os << "index : ";
     for (; it != serverBlock.mIndexs.end(); ++it)

--- a/src/ServerInfo.cpp
+++ b/src/ServerInfo.cpp
@@ -1,0 +1,32 @@
+#include "ServerInfo.hpp"
+
+ServerInfo::ServerInfo(const ServerBlock &serverBlock, const std::vector<LocationBlock> &locationBlocks)
+    : mServerBlock(serverBlock), mLocationBlocks(locationBlocks)
+{
+}
+
+const ServerBlock &ServerInfo::getServerBlock() const
+{
+    return mServerBlock;
+}
+
+const std::vector<LocationBlock> &ServerInfo::getLocationBlocks() const
+{
+    return mLocationBlocks;
+}
+
+std::ostream &operator<<(std::ostream &os, const ServerInfo &serverInfo)
+{
+    // locationBlock.mLocationPath
+    std::vector<LocationBlock>::const_iterator it = serverInfo.mLocationBlocks.begin();
+    os << "print ServerInfo " << std::endl;
+    os << "Server " << std::endl;
+    os << serverInfo.mServerBlock << std::endl;
+    os << "Location " << std::endl;
+    for (; it != serverInfo.mLocationBlocks.end(); ++it)
+    {
+        os << *it << std::endl;
+    }
+    os << std::endl;
+    return os;
+}

--- a/www/a.conf
+++ b/www/a.conf
@@ -1,9 +1,6 @@
 http {
 	root a;
-  #include    conf/mime.types;
   index    a;
-
-
   server { # main server
 		error_page 303;
     listen       80; ##port(server name 먼저 확인), IP+port(요청 IP와 port대조), IP(default port)
@@ -11,6 +8,7 @@ http {
     root         wwww;
 
 	location  / {
+		root b;
   	error_page 404 /404.html;
 		index b;
 		limit_except deny GET;
@@ -18,8 +16,24 @@ http {
 	  }
 
 	location /files/ {
-		index c;
          root /var/www/html/files;
+         autoindex on;
+				 index cc;
+      }
+	}
+
+  server { # main server
+		error_page 303;
+    listen       8080; ##port(server name 먼저 확인), IP+port(요청 IP와 port대조), IP(default port)
+    server_name  localhost2; ## 요청 host header와 일치하는 서버네임, 선행 와일드카드, 후행 와일드카드, 정규식, 기본서버
+    root         wwww;
+
+	location  / {
+		limit_except deny GET;
+		limit_except deny POST;
+	  }
+
+	location /a/ {
          autoindex on;
 				 index cc;
       }


### PR DESCRIPTION
### Summary
- ServerInfo클래스를 생성했습니다.
- BlockBuild 리셋 논리를 수정했습니다.
### Description
- **ServerInfo**
   - ServerBlock, ServerBlock과 연관된 LocationBlock의 vector을 멤버변수로 가지고 있습니다
   - 이에 맞게 Config 클래스를 수정했습니다.(생성자, 매개변수, createInstance)
   - std::vector<std::pair<std::string, std::vector<std::string> > > mServerStr;를 std::vector\<ServerInfo>로 수정했습니다.

- **BlockBuild 리셋 논리 수정**
    - 로직상 부모의 지시어가 있고 하위의 block에 동일한 지시어가 있을때 덮어쓰여지는것 까지는 잘됐습니다.
    - nginx상 부모에 root a;가 있고 serverBlock에서 root가 있으면 있는 값으로 대체가 되고 없으면 부모의 값으로 반영이 되야 합니다.
    - 하지만 이전의 로직으로는 부모의 값으로 반영이 되는게 아닌 앞서 나온 동등한 블록의 값으로 반영이 되는 문제를 확인했습니다.
    - 이유는  이전 Config의 22번째줄에서 block을 만들기전 기본값으로만 reset을 해줍니다.
    - 그래서 부모의 block의 getter을 만들고 부모개체를 받아서 부모의 값도 reset을 하게 수정해줬습니다.
 
### TODO
- errorPage가 애매해서 일단 벡터로 pushback만 해놓은 상태입니다.
- cgi은 아직 이해가 안돼서 나중에 locationBlock의 매개변수 locationDirective의 init 함수의 수정이 필요합니다.
- 유효성 검사를 위해 많은 테스트가 필요할것 같습니다.