### PR TITLE
[Refact] Parse 클래스 pair 자료형 ServerInfoStr 클래스로 리펙토링

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ SRCS = main.cpp \
 			 BlockBuilder.cpp \
 			 Parse.cpp \
 			 ServerInfo.cpp \
+			 ServerInfoStr.cpp \
 
 INC = include
 

--- a/include/Config.hpp
+++ b/include/Config.hpp
@@ -6,15 +6,13 @@
 #include "LocationBlock.hpp"
 #include "ServerBlock.hpp"
 #include "ServerInfo.hpp"
+#include "ServerInfoStr.hpp"
 #include <cassert>
 #include <fstream>
 #include <iostream>
 #include <map>
 #include <sstream>
 #include <vector>
-
-typedef std::vector<std::string> LocationVec;
-typedef std::pair<std::string, LocationVec> ServerLocPair;
 
 class Config
 {
@@ -30,9 +28,7 @@ class Config
     static Config *mInstance;
 
   public:
-    // clang-format off
-    static void createInstance(std::string httpString, std::vector<std::pair<std::string, std::vector<std::string> > > mServerStr);
-    // clang-format on
+    static void createInstance(const std::string &httpString, const std::vector<ServerInfoStr> &serverInfoStrs);
     static Config &getInstance();
     static void deleteInstance(); // 새로운 config를 만들고 싶을때?
     static const std::vector<ServerInfo> &getServerInfos();

--- a/include/Parse.hpp
+++ b/include/Parse.hpp
@@ -1,19 +1,17 @@
 #ifndef PARSE_HPP
 #define PARSE_HPP
 
+#include "ServerInfoStr.hpp"
 #include <fstream>
 #include <iostream>
-#include <vector>
 
 class Parse
 {
   private:
-    typedef std::vector<std::string> LocationVec;
-    typedef std::pair<std::string, LocationVec> ServerLocPair;
     std::ifstream mFile;
     int mDepth;
     std::string mHttpStr;
-    std::vector<ServerLocPair> mServerLocPairs;
+    std::vector<ServerInfoStr> mServerInfoStrs;
     void storeHttpStr(std::string &line);
     void storeServerStr(std::string &line);
     std::string storeLocationStr(std::string &line);
@@ -29,7 +27,7 @@ class Parse
     Parse(const char *path);
     ~Parse();
     const std::string &getHttpStr() const;
-    const std::vector<ServerLocPair> &getServerLocPairs() const;
+    const std::vector<ServerInfoStr> &getServerInfoStrs() const;
 };
 
 #endif

--- a/include/ServerInfoStr.hpp
+++ b/include/ServerInfoStr.hpp
@@ -1,0 +1,19 @@
+#ifndef SERVERINFOSTR_HPP
+#define SERVERINFOSTR_HPP
+
+#include <string>
+#include <vector>
+
+class ServerInfoStr
+{
+  private:
+    std::string mServerStr;
+    std::vector<std::string> mLocationStrs;
+
+  public:
+    ServerInfoStr(const std::string &serverStr, const std::vector<std::string> &locationStrs);
+    const std::string &getServerStr() const;
+    const std::vector<std::string> &getLocationStrs() const;
+};
+
+#endif

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -17,18 +17,18 @@ Config::Config(std::vector<ServerInfo> serverInfos)
 }
 
 // clang-format off
-void Config::createInstance(std::string httpString, std::vector<std::pair<std::string, std::vector<std::string> > > mServerStr)
+void Config::createInstance(const std::string &httpString, const std::vector<ServerInfoStr> &serverInfoStrs)
 // clang-format on
 {
     BlockBuilder builder;
     builder.parseConfig(Http, httpString);
     const HttpBlock httpblock = builder.buildHttpBlock();
 
-    for (size_t i = 0; i < mServerStr.size(); ++i)
+    for (size_t i = 0; i < serverInfoStrs.size(); ++i)
     {
         builder.resetServerBlockConfig(httpblock);
-        const std::string &serverString = mServerStr[i].first;
-        const std::vector<std::string> &locationStrings = mServerStr[i].second;
+        const std::string &serverString = serverInfoStrs[i].getServerStr();
+        const std::vector<std::string> &locationStrings = serverInfoStrs[i].getLocationStrs();
 
         builder.parseConfig(Server, serverString);
         ServerBlock serverBlock = builder.buildServerBlock();

--- a/src/Parse.cpp
+++ b/src/Parse.cpp
@@ -124,13 +124,13 @@ Parse::Parse(const char *path)
 
 Parse::~Parse()
 {
-    mServerLocPairs.clear();
+    mServerInfoStrs.clear();
 }
 
 void Parse::storeHttpStr(std::string &line)
 {
     mHttpStr = "";
-    mServerLocPairs.clear();
+    mServerInfoStrs.clear();
 
     skipDirective(line, std::strlen("http"));
     while (!mFile.eof() || line.size() != 0)
@@ -158,7 +158,7 @@ void Parse::storeHttpStr(std::string &line)
 void Parse::storeServerStr(std::string &line)
 {
     std::string serverStr;
-    LocationVec locationStrVec;
+    std::vector<std::string> locationStrVec;
 
     skipDirective(line, std::strlen("server"));
 
@@ -171,7 +171,7 @@ void Parse::storeServerStr(std::string &line)
         if (line[0] == '}')
         {
             checkCloseBrace(line);
-            mServerLocPairs.push_back(std::make_pair(serverStr, locationStrVec));
+            mServerInfoStrs.push_back(ServerInfoStr(serverStr, locationStrVec));
             return;
         }
         else if (line.find("location") == 0)
@@ -221,7 +221,7 @@ const std::string &Parse::getHttpStr() const
     return mHttpStr;
 }
 
-const std::vector<Parse::ServerLocPair> &Parse::getServerLocPairs() const
+const std::vector<ServerInfoStr> &Parse::getServerInfoStrs() const
 {
-    return mServerLocPairs;
+    return mServerInfoStrs;
 }

--- a/src/ServerInfoStr.cpp
+++ b/src/ServerInfoStr.cpp
@@ -1,0 +1,16 @@
+#include "ServerInfoStr.hpp"
+
+ServerInfoStr::ServerInfoStr(const std::string &serverStr, const std::vector<std::string> &locationStrs)
+    : mServerStr(serverStr), mLocationStrs(locationStrs)
+{
+}
+
+const std::string &ServerInfoStr::getServerStr() const
+{
+    return mServerStr;
+}
+
+const std::vector<std::string> &ServerInfoStr::getLocationStrs() const
+{
+    return mLocationStrs;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,5 +8,5 @@ int main()
 {
     Parse a("www/a.conf");
     std::cout << "serverStr : " << a.getHttpStr() << std::endl;
-    Config::createInstance(a.getHttpStr(), a.getServerLocPairs());
+    Config::createInstance(a.getHttpStr(), a.getServerInfoStrs());
 }


### PR DESCRIPTION
#18 Parse 클래스에서 pair를 클래스로 리펙토링 했습니다.

- ServerInfoStr 클래스가 추가되었습니다.
- Parse의 getServerLocPairs 메소드가 getServerInfoStrs로 변경되었습니다.
- Config 클래스의 createInstance의 인자를 상수 참조자로 받는 것으로 리펙토링 했습니다.