### PR TITLE
[Feat] ServerManager와 Event 클래스 작성

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ SRCS = main.cpp \
 			 Parse.cpp \
 			 ServerInfo.cpp \
 			 ServerInfoStr.cpp \
+			 ServerManager.cpp
 
 INC = include
 

--- a/include/AEvent.hpp
+++ b/include/AEvent.hpp
@@ -5,13 +5,14 @@
 
 class AEvent
 {
-  private:
+  protected:
     // response
     // request
     const Server &mServer;
 
   public:
     AEvent(const Server &server);
+    virtual ~AEvent();
     virtual void handle() = 0;
 };
 

--- a/include/AEvent.hpp
+++ b/include/AEvent.hpp
@@ -11,6 +11,7 @@ class AEvent
     const Server &mServer;
 
   public:
+    AEvent(const Server &server);
     virtual void handle() = 0;
 };
 

--- a/include/Accept.hpp
+++ b/include/Accept.hpp
@@ -1,0 +1,14 @@
+#ifndef ACCEPT_HPP
+#define ACCEPT_HPP
+
+#include "AEvent.hpp"
+
+class Accept : public AEvent
+{
+  public:
+    Accept(const Server &server);
+    ~Accept();
+    void handle();
+};
+
+#endif

--- a/include/BlockBuilder.hpp
+++ b/include/BlockBuilder.hpp
@@ -16,12 +16,14 @@ enum unit
     mega = 1000000,
     giga = 100000000,
 };
+
 enum blockType
 {
-    Http,
-    Server,
-    Location,
+    E_HTTP,
+    E_SERVER,
+    E_LOCATION,
 };
+
 class BlockBuilder
 {
 

--- a/include/Kqueue.hpp
+++ b/include/Kqueue.hpp
@@ -10,12 +10,13 @@ class Kqueue
   private:
     static int mKq;
     static std::vector<struct kevent> mNewEvents; // kqueue에 등록시켜줄 이벤트
-    static struct kevent mHandleEvents[8];        // 처리해줘야 하는 이벤트
+    static struct kevent mHandleEvents[8];        // kqueue에서 받아온 처리해줘야 하는 이벤트
 
   public:
     static void init();
     static void addEvent(const struct kevent &event);
     static void handleEvents();
+    static void pushAcceptEvent(); // 뺄지 넣을지 고민중
 };
 
 #endif

--- a/include/Kqueue.hpp
+++ b/include/Kqueue.hpp
@@ -10,7 +10,8 @@ class Kqueue
   private:
     static int mKq;
     static std::vector<struct kevent> mNewEvents; // kqueue에 등록시켜줄 이벤트
-    static struct kevent mHandleEvents[8];        // kqueue에서 받아온 처리해줘야 하는 이벤트
+    static const int MAX_EVENT_CNT = 8;
+    static struct kevent mHandleEvents[MAX_EVENT_CNT]; // kqueue에서 받아온 처리해줘야 하는 이벤트
 
   public:
     static void init();

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -5,21 +5,28 @@
 #include <sys/socket.h>
 #include <vector>
 
-#include "LocationBlock.hpp"
-#include "ServerBlock.hpp"
-
-class ServerBlock;
+#include "ServerInfo.hpp"
 
 class Server
 {
   private:
-    typedef std::vector<LocationBlock> LocationBlocks;
     const int mSocket;
     const unsigned int mPort;
-    std::vector<ServerBlock> mServerBlocks;
-    std::vector<LocationBlocks> mLocationBlocks;
+    std::vector<ServerInfo> mServerInfos;
 
   public:
+    Server(const ServerInfo &serverInfo);
+    // const Server &operator=(const Server &)
+    // {
+
+    //     return *this;
+    // }
+    const unsigned int &getPort() const;
+    const std::vector<ServerInfo> &getServerInfos() const;
+    void addServerInfo(const ServerInfo &serverInfo);
+
+    // Debugging - TODO : 추후 삭제
+    friend std::ostream &operator<<(std::ostream &os, const Server &serverb);
 };
 
 #endif

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -5,15 +5,19 @@
 #include <sys/socket.h>
 #include <vector>
 
+#include "LocationBlock.hpp"
+#include "ServerBlock.hpp"
+
 class ServerBlock;
 
 class Server
 {
   private:
-    // const int mSocketFd;
-    // const unsigned int mPort;
-    // std::string mListenIp;
-    // std::vector<ServerBlock> mServerBlocks;
+    typedef std::vector<LocationBlock> LocationBlocks;
+    const int mSocket;
+    const unsigned int mPort;
+    std::vector<ServerBlock> mServerBlocks;
+    std::vector<LocationBlocks> mLocationBlocks;
 
   public:
 };

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -21,9 +21,11 @@ class Server
 
     //     return *this;
     // }
-    const unsigned int &getPort() const;
+		const int getSocket() const;
+    const unsigned int getPort() const;
     const std::vector<ServerInfo> &getServerInfos() const;
     void addServerInfo(const ServerInfo &serverInfo);
+    void listen();
 
     // Debugging - TODO : 추후 삭제
     friend std::ostream &operator<<(std::ostream &os, const Server &serverb);

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -16,12 +16,8 @@ class Server
 
   public:
     Server(const ServerInfo &serverInfo);
-    // const Server &operator=(const Server &)
-    // {
-
-    //     return *this;
-    // }
-		const int getSocket() const;
+    ~Server();
+    const int getSocket() const;
     const unsigned int getPort() const;
     const std::vector<ServerInfo> &getServerInfos() const;
     void addServerInfo(const ServerInfo &serverInfo);

--- a/include/ServerManager.hpp
+++ b/include/ServerManager.hpp
@@ -2,14 +2,18 @@
 #define SERVERMANAGER_HPP
 
 #include "Server.hpp"
+#include <iostream>
 #include <vector>
 
 class ServerManager
 {
   private:
     std::vector<Server> mServers;
+  	void pushServerInfo(const ServerInfo &serverInfo);
 
   public:
-    ServerManager();
-}
+    ServerManager(const std::vector<ServerInfo> &serverInfos);
+    void run();
+};
+
 #endif

--- a/include/ServerManager.hpp
+++ b/include/ServerManager.hpp
@@ -1,0 +1,15 @@
+#ifndef SERVERMANAGER_HPP
+#define SERVERMANAGER_HPP
+
+#include "Server.hpp"
+#include <vector>
+
+class ServerManager
+{
+  private:
+    std::vector<Server> mServers;
+
+  public:
+    ServerManager();
+}
+#endif

--- a/src/AEvent.cpp
+++ b/src/AEvent.cpp
@@ -1,0 +1,5 @@
+#include "AEvent.hpp"
+
+AEvent::AEvent(const Server &server) : mServer(server)
+{
+}

--- a/src/AEvent.cpp
+++ b/src/AEvent.cpp
@@ -3,3 +3,7 @@
 AEvent::AEvent(const Server &server) : mServer(server)
 {
 }
+
+AEvent::~AEvent()
+{
+}

--- a/src/Accept.cpp
+++ b/src/Accept.cpp
@@ -1,0 +1,22 @@
+#include "Accept.hpp"
+#include "Kqueue.hpp"
+
+Accept::Accept(const Server &server) : AEvent(server)
+{
+}
+
+Accept::~Accept()
+{
+}
+
+void Accept::handle()
+{
+    struct kevent newEvent;
+    struct sockaddr_in clientAddr;
+    socklen_t clientAddrSize = sizeof(clientAddr);
+    int clientSocket = accept(mServer.getSocket(), (struct sockaddr *)&clientAddr, &clientAddrSize);
+
+    // EV_SET(&newEvent, clientSocket, EVFILT_READ, EV_ADD, 0, 0, new Read());
+
+    Kqueue::addEvent(newEvent);
+}

--- a/src/BlockBuilder.cpp
+++ b/src/BlockBuilder.cpp
@@ -110,15 +110,15 @@ void BlockBuilder::parseConfig(const enum blockType blockType, const std::string
         {
             if (isKeyValue == true)
             {
-                if (blockType == Http)
+                if (blockType == E_HTTP)
                 {
                     mHttpDirective.checkDirective(subtoken);
                 }
-                else if (blockType == Server)
+                else if (blockType == E_SERVER)
                 {
                     mServerDirective.checkDirective(subtoken);
                 }
-                else if (blockType == Location)
+                else if (blockType == E_LOCATION)
                 {
                     mLocationDirective.checkDirective(subtoken);
                 }

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -7,13 +7,13 @@ Config::Config(std::vector<ServerInfo> serverInfos)
 {
     mServerInfos = serverInfos;
     // 디버그용 프린트
-    std::vector<ServerInfo>::const_iterator it = mServerInfos.begin();
-    for (; it != mServerInfos.end(); ++it)
-    {
-        std::cout << "*------------*" << std::endl;
-        std::cout << *it << std::endl;
-        std::cout << "*------------*" << std::endl;
-    }
+    // std::vector<ServerInfo>::const_iterator it = mServerInfos.begin();
+    // for (; it != mServerInfos.end(); ++it)
+    // {
+    //     std::cout << "*------------*" << std::endl;
+    //     std::cout << *it << std::endl;
+    //     std::cout << "*------------*" << std::endl;
+    // }
 }
 
 // clang-format off
@@ -21,7 +21,7 @@ void Config::createInstance(const std::string &httpString, const std::vector<Ser
 // clang-format on
 {
     BlockBuilder builder;
-    builder.parseConfig(Http, httpString);
+    builder.parseConfig(E_HTTP, httpString);
     const HttpBlock httpblock = builder.buildHttpBlock();
 
     for (size_t i = 0; i < serverInfoStrs.size(); ++i)
@@ -30,14 +30,14 @@ void Config::createInstance(const std::string &httpString, const std::vector<Ser
         const std::string &serverString = serverInfoStrs[i].getServerStr();
         const std::vector<std::string> &locationStrings = serverInfoStrs[i].getLocationStrs();
 
-        builder.parseConfig(Server, serverString);
+        builder.parseConfig(E_SERVER, serverString);
         ServerBlock serverBlock = builder.buildServerBlock();
 
         std::vector<LocationBlock> locationBlocks;
         for (size_t j = 0; j < locationStrings.size(); ++j)
         {
             builder.resetLocationBlockConfig(serverBlock);
-            builder.parseConfig(Location, locationStrings[j]);
+            builder.parseConfig(E_LOCATION, locationStrings[j]);
             LocationBlock locationBlock = builder.buildLocationBlock();
             locationBlocks.push_back(locationBlock);
         }

--- a/src/Kqueue.cpp
+++ b/src/Kqueue.cpp
@@ -28,4 +28,18 @@ void Kqueue::handleEvents()
     {
         reinterpret_cast<AEvent *>(mHandleEvents[i].udata)->handle();
     }
+    if (!mNewEvents.empty())
+    {
+        mNewEvents.clear();
+    }
+}
+
+void Kqueue::pushAcceptEvent()
+{
+    int n = kevent(mKq, &mNewEvents[0], mNewEvents.size(), NULL, 0, NULL);
+    if (n == -1)
+    {
+        throw std::runtime_error("Error Kqueue::pushAcceptEvent(): kqueue에 accept 이벤트 넣기 실패");
+    }
+    mNewEvents.clear();
 }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -1,6 +1,7 @@
 #include "Server.hpp"
 #include "Accept.hpp"
 #include "Kqueue.hpp"
+#include <unistd.h>
 
 Server::Server(const ServerInfo &serverInfo)
     : mSocket(socket(AF_INET, SOCK_STREAM, 0)), mPort(serverInfo.getServerBlock().getPort())
@@ -10,6 +11,11 @@ Server::Server(const ServerInfo &serverInfo)
     {
         throw std::runtime_error("Error Server::Server(): socket() 소켓 생성 실패");
     }
+}
+
+Server::~Server()
+{
+    close(mSocket);
 }
 
 void Server::listen()

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -1,1 +1,43 @@
 #include "Server.hpp"
+
+Server::Server(const ServerInfo &serverInfo)
+    : mSocket(socket(AF_INET, SOCK_STREAM, 0)), mPort(serverInfo.getServerBlock().getPort())
+{
+    mServerInfos.push_back(serverInfo);
+    if (mSocket == -1)
+    {
+        throw std::runtime_error("Error Server::Server() socket() - 소켓 생성 실패");
+    }
+}
+
+const unsigned int &Server::getPort() const
+{
+    return mPort;
+}
+
+void Server::addServerInfo(const ServerInfo &serverInfo)
+{
+    mServerInfos.push_back(serverInfo);
+}
+
+// Debugging TODO - 추후 삭제
+std::ostream &operator<<(std::ostream &os, const Server &serverb)
+{
+    os << "[Server] mSocket : " << serverb.mSocket << std::endl;
+    os << "[Server] mPort : " << serverb.mPort << std::endl;
+
+    std::vector<ServerInfo>::const_iterator it = serverb.mServerInfos.begin();
+
+    os << "[Server] mServerInfosDivPort : " << std::endl;
+    for (; it != serverb.mServerInfos.end(); ++it)
+    {
+        os << *it << " ";
+    }
+    os << std::endl;
+    return os;
+}
+
+const std::vector<ServerInfo> &Server::getServerInfos() const
+{
+    return mServerInfos;
+}

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -1,11 +1,13 @@
 #include "Server.hpp"
 #include "Accept.hpp"
 #include "Kqueue.hpp"
+#include <fcntl.h>
 #include <unistd.h>
 
 Server::Server(const ServerInfo &serverInfo)
     : mSocket(socket(AF_INET, SOCK_STREAM, 0)), mPort(serverInfo.getServerBlock().getPort())
 {
+    fcntl(mSocket, F_SETFL, O_NONBLOCK);
     mServerInfos.push_back(serverInfo);
     if (mSocket == -1)
     {

--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -1,0 +1,68 @@
+#include "ServerManager.hpp"
+#include "Kqueue.hpp"
+
+// 서버 매니저의 역할
+// 서버를 생성
+// kqueue 언제 listenSocket을 넣어줄지
+
+// 서버 매니저 생성자에서 서버를 생성하는데 동일 포트면 소켓을 열지 않고
+// 서버
+// 에러 체크도 해줘 -> 같은 포트에 같은 서버이름이면 중복에러
+
+// run에서 해줄지
+
+// Kevent::handleEvents() 호출
+
+ServerManager::ServerManager(const std::vector<ServerInfo> &serverInfos)
+{
+    for (size_t i = 0; i < serverInfos.size(); ++i)
+    {
+        pushServerInfo(serverInfos[i]);
+    }
+}
+
+// 포트 번호 체크 및 결과값 반환
+void ServerManager::pushServerInfo(const ServerInfo &serverInfo)
+{
+    unsigned int checkPort = serverInfo.getServerBlock().getPort();
+    std::string checkServerName = serverInfo.getServerBlock().getServerName();
+
+    for (size_t i = 0; i < mServers.size(); ++i)
+    {
+        if (checkPort == mServers[i].getPort())
+        {
+            const std::vector<ServerInfo> &checkServerInfos = mServers[i].getServerInfos();
+            for (size_t j = 0; j < checkServerInfos.size(); ++j)
+            {
+                if (checkServerName == checkServerInfos[j].getServerBlock().getServerName())
+                {
+                    throw std::runtime_error("Error ServerManager::checkServerInfo(): 동일 포트 동일 호스트 중복 에러");
+                }
+                else
+                {
+                    mServers[i].addServerInfo(serverInfo);
+                    return;
+                }
+            }
+        }
+    }
+    mServers.push_back(Server(serverInfo));
+}
+
+void ServerManager::run()
+{
+    // Debugging TODO - 추후 삭제
+    // std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" << std::endl;
+    // std::vector<Server>::iterator iter = mServers.begin();
+    // for (; iter != mServers.end(); ++iter)
+    // {
+    //     std::cout << *iter << std::endl;
+    // }
+    // std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" << std::endl;
+    // Debugging
+
+    // while (1)
+    // {
+    //     Kqueue::handleEvents();
+    // }
+}

--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -19,6 +19,11 @@ ServerManager::ServerManager(const std::vector<ServerInfo> &serverInfos)
     {
         pushServerInfo(serverInfos[i]);
     }
+    for (size_t i = 0; i < mServers.size(); ++i)
+    {
+        mServers[i].listen();
+    }
+    Kqueue::pushAcceptEvent();
 }
 
 // 포트 번호 체크 및 결과값 반환
@@ -60,9 +65,8 @@ void ServerManager::run()
     // }
     // std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" << std::endl;
     // Debugging
-
-    // while (1)
-    // {
-    //     Kqueue::handleEvents();
-    // }
+    while (1)
+    {
+        Kqueue::handleEvents();
+    }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,11 +2,14 @@
 #include "Config.hpp"
 #include "LocationBlock.hpp"
 #include "Parse.hpp"
-#include "ServerBlock.hpp"
+#include "Server.hpp"
+#include "ServerManager.hpp"
 
 int main()
 {
     Parse a("www/a.conf");
     std::cout << "serverStr : " << a.getHttpStr() << std::endl;
     Config::createInstance(a.getHttpStr(), a.getServerInfoStrs());
+    ServerManager sm(Config::getInstance().getServerInfos());
+    sm.run();
 }


### PR DESCRIPTION
### [ServerManager 클래스 생성 및 구현]
- ServerInfo 벡터의 정보를 토대로 포트별로 Server 인스턴스 생성
- 동일 포트 동일 서버 이름이 있으면 예외처리
- 동일 포트의 서버 인스턴스가 존재하나 다른 서버 이름인 경우에는 서버 인스턴스의 ServerInfo 벡터에 push_back()
 

### [Config 클래스 / BlockBuilder 클래스 enum 값 변경]
- enum blockType의 Server와 ServerManager 클래스의 멤버변수 std::vector<Server> mServers 가 
   'Server' 라는 동일 키워드로 인해 컴파일 에러 발생
   -> enum 값을 변경하여 해당 에러 해결


### [AEvent 클래스 / Accept 클래스 생성 및 구현]
- 추상클래스인 AEvent의 생성자/소멸자 구현
- AEvent의 구현 클래스인 Accept 클래스 생성자/소멸자 및 가상함수 handle()의 오버라이딩 구현