### PR TITLE
[FIX] EVENT 수정

### DIFF
--- a/include/event/AEvent.hpp
+++ b/include/event/AEvent.hpp
@@ -7,6 +7,7 @@
 
 #define EVENT_FINISH true
 #define EVENT_CONTINUE false
+#define BUFFER_SIZE 32768
 
 class AEvent
 {

--- a/include/event/ReadFileEvent.hpp
+++ b/include/event/ReadFileEvent.hpp
@@ -7,7 +7,6 @@ class ReadFileEvent : public AEvent
 {
   private:
     const int mFileFd;
-    static const int BUFFER_SIZE = 1024; // todo 테스트를 통해 적절한 값 찾기
     char mBuffer[BUFFER_SIZE];
     int mFileSize;
     int mReadSize;

--- a/include/event/ReadRequestEvent.hpp
+++ b/include/event/ReadRequestEvent.hpp
@@ -6,7 +6,6 @@
 class ReadRequestEvent : public AEvent
 {
   private:
-    static const int BUFFER_SIZE = 1024; // todo 테스트를 통해 적절한 값 찾기
     std::string mStringBuffer;
 
   public:

--- a/include/parse/Config.hpp
+++ b/include/parse/Config.hpp
@@ -19,12 +19,8 @@ class Config
   private:
     Config();
     Config &operator=(const Config &rhs);
-    // clang-format off
     Config(std::vector<ServerInfo> serverInfos);
-		static std::vector<ServerInfo> mServerInfos;
-    // Config(std::vector<std::pair<ServerBlock, std::vector<LocationBlock> > > mServerBlockGroups);
-		// static std::vector<std::pair<ServerBlock, std::vector<LocationBlock> > > mServerBlockGroups;
-    // clang-format on
+    static std::vector<ServerInfo> mServerInfos;
     static Config *mInstance;
     static bool compareByPathLength(const LocationBlock &a, const LocationBlock &b);
 

--- a/include/server/Kqueue.hpp
+++ b/include/server/Kqueue.hpp
@@ -18,6 +18,9 @@ class Kqueue
     static void addEvent(const struct kevent &event);
     static void handleEvents();
     static void pushAcceptEvent(); // 뺄지 넣을지 고민중
+
+    static void deleteEvent(int fd, int filter);
+    static void closeKq();
 };
 
 #endif

--- a/src/event/ReadFileEvent.cpp
+++ b/src/event/ReadFileEvent.cpp
@@ -21,12 +21,15 @@ int ReadFileEvent::handle()
     {
         // 처리 필요 autoindex 또는 301 또는 404
         // write
+        close(mFileFd);
+        delete this;
         return EVENT_FINISH;
     }
     mReadSize += n;
     mBody.append(mBuffer, n);
     if (mReadSize == mFileSize)
     {
+        close(mFileFd);
         mResponse.init(mHttpStatusCode, mReadSize);
         std::string message;
         message = mResponse.getStartLine() + "\r\n" + mResponse.getHead() + "\r\n\r\n" + mBody;
@@ -34,6 +37,7 @@ int ReadFileEvent::handle()
         struct kevent newEvent;
         EV_SET(&newEvent, mClientSocket, EVFILT_WRITE, EV_ADD, 0, 0, new WriteEvent(mServer, mClientSocket, message));
         Kqueue::addEvent(newEvent);
+        delete this;
         return EVENT_FINISH;
     }
     else

--- a/src/event/ReadRequestEvent.cpp
+++ b/src/event/ReadRequestEvent.cpp
@@ -60,7 +60,6 @@ void ReadRequestEvent::makeReadFileEvent()
 int ReadRequestEvent::handle()
 {
     char buffer[BUFFER_SIZE];
-    std::cout << "Debug" << std::endl;
     int n = read(mClientSocket, buffer, BUFFER_SIZE);
     if (n < 0)
     {

--- a/src/event/ReadRequestEvent.cpp
+++ b/src/event/ReadRequestEvent.cpp
@@ -78,7 +78,7 @@ int ReadRequestEvent::handle()
     {
         return EVENT_FINISH;
     }
-    else if (status >= 0)
+    else if (status >= 200)
     {
         makeReadFileEvent();
     }

--- a/src/event/Request.cpp
+++ b/src/event/Request.cpp
@@ -133,6 +133,7 @@ void Request::parseRequestHeader(std::string &buffer)
             mStatus = 400; // Bad Request
             return;
         }
+        mStatus = 200;
         buffer = buffer.substr(pos + 4);
         mRequestLine = E_REQUEST_CONTENTS;
     }

--- a/src/event/Request.cpp
+++ b/src/event/Request.cpp
@@ -2,7 +2,7 @@
 #include "util.hpp"
 #include <sstream>
 
-Request::Request() : mVersion("HTTP/1.1"), mStatus(0)
+Request::Request() : mVersion("HTTP/1.1"), mRequestLine(E_START_LINE), mStatus(0)
 {
 }
 

--- a/src/event/WriteEvent.cpp
+++ b/src/event/WriteEvent.cpp
@@ -1,4 +1,8 @@
 #include "WriteEvent.hpp"
+#include "Kqueue.hpp"
+#include "ReadRequestEvent.hpp"
+
+#define BUFFER_SIZE 3000
 
 WriteEvent::WriteEvent(const Server &server, int clientSocket, std::string message)
     : AEvent(server, clientSocket), mMessage(message), mWriteSize(0), mResponseSize(message.size())
@@ -13,21 +17,29 @@ int WriteEvent::handle()
 {
     int n;
 
-    n = write(mClientSocket, mMessage.c_str(), mMessage.size());
+    // std::cout << "write event start" << std::endl;
+    n = write(mClientSocket, mMessage.c_str(), mMessage.size() < BUFFER_SIZE ? mMessage.size() : BUFFER_SIZE);
+    // std::cout << "write event end" << std::endl;
     mWriteSize += n;
     if (n == -1)
     {
         // todo 모름
+        close(mClientSocket);
+        delete this;
         return EVENT_CONTINUE;
     }
     else if (mWriteSize == mResponseSize)
     {
-
+        Kqueue::deleteEvent(mClientSocket, EVFILT_WRITE);
+        struct kevent newEvent;
+        EV_SET(&newEvent, mClientSocket, EVFILT_READ, EV_ADD, 0, 0, new ReadRequestEvent(mServer, mClientSocket));
+        Kqueue::addEvent(newEvent);
+        delete this;
         return EVENT_FINISH;
     }
     else
     {
-        mMessage.substr(n, mMessage.size());
+        mMessage.substr(n);
         return EVENT_CONTINUE;
     }
 }

--- a/src/event/WriteEvent.cpp
+++ b/src/event/WriteEvent.cpp
@@ -2,7 +2,7 @@
 #include "Kqueue.hpp"
 #include "ReadRequestEvent.hpp"
 
-#define BUFFER_SIZE 3000
+#define BUFFER_SIZE 32768
 
 WriteEvent::WriteEvent(const Server &server, int clientSocket, std::string message)
     : AEvent(server, clientSocket), mMessage(message), mWriteSize(0), mResponseSize(message.size())
@@ -39,7 +39,7 @@ int WriteEvent::handle()
     }
     else
     {
-        mMessage.substr(n);
+        mMessage = mMessage.substr(n);
         return EVENT_CONTINUE;
     }
 }

--- a/src/event/WriteEvent.cpp
+++ b/src/event/WriteEvent.cpp
@@ -2,8 +2,6 @@
 #include "Kqueue.hpp"
 #include "ReadRequestEvent.hpp"
 
-#define BUFFER_SIZE 32768
-
 WriteEvent::WriteEvent(const Server &server, int clientSocket, std::string message)
     : AEvent(server, clientSocket), mMessage(message), mWriteSize(0), mResponseSize(message.size())
 {

--- a/src/parse/Config.cpp
+++ b/src/parse/Config.cpp
@@ -16,9 +16,7 @@ Config::Config(std::vector<ServerInfo> serverInfos)
     // }
 }
 
-// clang-format off
 void Config::createInstance(const std::string &httpString, const std::vector<ServerInfoStr> &serverInfoStrs)
-// clang-format on
 {
     BlockBuilder builder;
     builder.parseConfig(E_HTTP, httpString);

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -18,12 +18,18 @@ Server::~Server()
 void Server::listen()
 {
     struct sockaddr_in serverAddr;
-    mSocket = socket(AF_INET, SOCK_STREAM, 0);
+    mSocket = socket(PF_INET, SOCK_STREAM, 0);
     if (mSocket == -1)
     {
         throw std::runtime_error("Error Server::Server(): socket() 소켓 생성 실패");
     }
-    fcntl(mSocket, F_SETFL, O_NONBLOCK);
+    int yes = 1;
+    if (setsockopt(mSocket, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int)) == -1)
+    {
+        assert(false);
+    }
+
+    fcntl(mSocket, F_SETFL, O_NONBLOCK, FD_CLOEXEC);
     // 서버 주소 설정
     serverAddr.sin_family = AF_INET;
     serverAddr.sin_addr.s_addr = INADDR_ANY;

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -77,6 +77,7 @@ void Server::addServerInfo(const ServerInfo &serverInfo)
 //    - on이면 autoindex, off 이면 404
 const std::vector<std::string> Server::getFilePath(const std::string &host, std::string path, bool &isFolder) const
 {
+    assert(path != "");
     std::vector<std::string> indexsPath;
     std::vector<std::string> filePath;
     std::string root;

--- a/src/server/ServerManager.cpp
+++ b/src/server/ServerManager.cpp
@@ -57,15 +57,6 @@ void ServerManager::pushServerInfo(const ServerInfo &serverInfo)
 
 void ServerManager::run()
 {
-    // Debugging TODO - 추후 삭제
-    // std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" << std::endl;
-    // std::vector<Server>::iterator iter = mServers.begin();
-    // for (; iter != mServers.end(); ++iter)
-    // {
-    //     std::cout << *iter << std::endl;
-    // }
-    // std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" << std::endl;
-    // Debugging
     while (1)
     {
         Kqueue::handleEvents();

--- a/www/a.conf
+++ b/www/a.conf
@@ -1,42 +1,15 @@
 http {
-	root a;
-  index    a;
-  server { # main server
-		error_page 303;
-    listen       80; ##port(server name 먼저 확인), IP+port(요청 IP와 port대조), IP(default port)
-    server_name  localhost; ## 요청 host header와 일치하는 서버네임, 선행 와일드카드, 후행 와일드카드, 정규식, 기본서버
-    root         wwww;
-
-	location  / {
-		root b;
-  	error_page 404 /404.html;
-		index b;
-		limit_except deny GET;
-		limit_except deny POST;
-	  }
-
-	location /files/ {
-         root /var/www/html/files;
-         autoindex on;
-				 index cc;
-      }
-	}
-
   server { # main server
 		error_page 303;
     listen       8080; ##port(server name 먼저 확인), IP+port(요청 IP와 port대조), IP(default port)
-    server_name  localhost2; ## 요청 host header와 일치하는 서버네임, 선행 와일드카드, 후행 와일드카드, 정규식, 기본서버
-    root         wwww;
+    server_name  localhost; ## 요청 host header와 일치하는 서버네임, 선행 와일드카드, 후행 와일드카드, 정규식, 기본서버
+    root         www;
 
 	location  / {
+  	error_page 404 /404.html;
+		index index.html index.htm;
 		limit_except deny GET;
 		limit_except deny POST;
 	  }
-
-	location /a/ {
-         autoindex on;
-				 index cc;
-      }
 	}
-	index d;
 }


### PR DESCRIPTION
### Summary
- Get 처리 여러 가지 사항들을 수정했습니다.
### Description
- 초기화가 미흡한 부분들을 추가했습니다.
  - mRequestLine이 mStartLine으로 초기화를 안 해줘서 문제가 있었습니다.
  - request 파싱이 끝나면 상태코드를 200으로 바꿔야 되는 이 부분이 안 되어 있어서 추가했습니다.
- read나 write가 실패하면 fd를 닫습니다. 
  - 이 부분은 kevent error flag를 확인하는 게 있어서 미리 처리가 가능할 것도 같아요.
  - fd를 닫기 때문에 소켓은 한번에 하나의 이벤트만 갖게 했습니다.
  - 예를 들어 ReadRequest 이벤트가 끝나면 ReadFile 이벤트를 생성하고 ReadRequest 이벤트를 delete 합니다.
- delete를 이벤트 메소드로 안에 넣었습니다. 
  - delete this
### TODO
- 파일이 없으면 에러 페이지 보내주기
- kevent handle 메소드 리턴값 void로 바꾸기
