### PR TITLE
feat: Configuration 파일의 error_page 지시어 처리

### DIFF
--- a/include/parse/BlockBuilder.hpp
+++ b/include/parse/BlockBuilder.hpp
@@ -7,14 +7,15 @@
 #include "LocationDirective.hpp"
 #include "ServerBlock.hpp"
 #include "ServerDirective.hpp"
+#include <map>
 #include <string>
 #include <vector>
 
 enum unit
 {
-    killo = 1000,
-    mega = 1000000,
-    giga = 100000000,
+    E_KILLO = 1000,
+    E_MEGA = 1000000,
+    E_GIGA = 100000000,
 };
 
 enum blockType
@@ -30,9 +31,8 @@ class BlockBuilder
   private:
     std::string mRoot;
     std::vector<std::string> mIndexs;
-    // todo : errorpage를 어떻게 받을것인가
-    // 예시 :  500 502 503 504 /50x.html; 또는 error_page  404 /404.html;
-    std::vector<std::string> mErrorPages;
+    std::vector<unsigned int> mErrorCodes;
+    std::map<int, std::string> mErrorPages;
     unsigned int mClientMaxBodySize;
 
     unsigned int mPort;
@@ -53,7 +53,7 @@ class BlockBuilder
     void updateConfig(const std::string &key, const std::string &value, bool isFirstValue, bool &isFirstIndex,
                       bool &isFirstErrorPage);
     std::string reduceMultipleSpaces(std::string token);
-    unsigned int convertNumber(const std::string &valueString, bool hasUnit);
+    bool tryConvertNumber(const std::string &valueString, bool hasUnit, unsigned int &result);
 
   public:
     BlockBuilder();
@@ -65,4 +65,4 @@ class BlockBuilder
     void resetLocationBlockConfig(const ServerBlock &serverBLock);
 };
 
-#endif // BLOCKBUILDER_HPP
+#endif

--- a/include/parse/HttpBlock.hpp
+++ b/include/parse/HttpBlock.hpp
@@ -5,31 +5,25 @@
 #include <limits>
 #include <map>
 #include <vector>
+#include <map>
 
-// 문제가 httpblock을 생성자로 다 만들려고 했다
-// 근데 httpblock을 만들려면 httpblock안의 checkDirective가 필요
-// 1. checkDirective을 다른 클래스로 옮기기
-// 1-1. config
-// 1-2. 다른 클래스 만들기
-// 2. httpblock을 기본값으로 일단 생성 후 setter로 값 바꿔주기
 class HttpBlock
 {
   protected:
-    // root 기본값 html, index index.html, errorpage ""(없음), client_max_body_size = 1m;
     std::string mRoot;
     std::vector<std::string> mIndexs;
-    std::vector<std::string> mErrorPages;
+    std::map<int, std::string> mErrorPages;
     unsigned int mClientMaxBodySize;
 
   public:
-    HttpBlock(std::string root, std::vector<std::string> index, std::vector<std::string> errorpage,
+    HttpBlock(std::string root, std::vector<std::string> index, std::map<int, std::string> errorpage,
               unsigned int clientMaxBodySize);
     HttpBlock(const HttpBlock &other);
     HttpBlock &operator=(const HttpBlock &rhs);
 
     const std::string &getRoot() const;
     const std::vector<std::string> &getIndexs() const;
-    const std::vector<std::string> &getErrorPages() const;
+    const std::map<int, std::string> &getErrorPages() const;
     unsigned int getClientMaxBodySize() const;
     // todo : friend 없애야함
     friend std::ostream &operator<<(std::ostream &os, const HttpBlock &httpBlock);

--- a/include/parse/HttpBlock.hpp
+++ b/include/parse/HttpBlock.hpp
@@ -5,7 +5,6 @@
 #include <limits>
 #include <map>
 #include <vector>
-#include <map>
 
 class HttpBlock
 {
@@ -16,8 +15,8 @@ class HttpBlock
     unsigned int mClientMaxBodySize;
 
   public:
-    HttpBlock(std::string root, std::vector<std::string> index, std::map<int, std::string> errorpage,
-              unsigned int clientMaxBodySize);
+    HttpBlock(const std::string &root, const std::vector<std::string> &index,
+              const std::map<int, std::string> &errorpage, unsigned int clientMaxBodySize);
     HttpBlock(const HttpBlock &other);
     HttpBlock &operator=(const HttpBlock &rhs);
 

--- a/include/parse/LocationBlock.hpp
+++ b/include/parse/LocationBlock.hpp
@@ -19,7 +19,7 @@ class LocationBlock : public ServerBlock
     bool mIsAllowedDelete;
 
   public:
-    LocationBlock(ServerBlock serverBlock, std::string locationPath, bool isAutoIndex, bool isAllowedGet,
+    LocationBlock(const ServerBlock &serverBlock, const std::string &locationPath, bool isAutoIndex, bool isAllowedGet,
                   bool isAllowedPost, bool isAllowedDelete);
     LocationBlock &operator=(const LocationBlock &rhs);
     const std::string &getLocationPath() const;

--- a/include/parse/ServerBlock.hpp
+++ b/include/parse/ServerBlock.hpp
@@ -6,20 +6,15 @@
 
 class ServerBlock : public HttpBlock
 {
-    // port 기본값 80, serverName "", return은 기본값이 없음
-    // 우리가 정해놓을까? redirectionCode = 0; path = "";
-    // listen의 중복을 허용하지 않고 port로 받음
-
   protected:
     unsigned int mPort;
-    // server_name도 중복이 되지만 허용 안하는것으로
     std::string mServerName;
     unsigned int mRedirectionCode;
     std::string mRedirectionPath;
 
   public:
-    ServerBlock(HttpBlock httpBlock, unsigned int port, std::string serverName, unsigned int redirectionCode,
-                std::string redirectionPath);
+    ServerBlock(const HttpBlock &httpBlock, unsigned int port, const std::string &serverName,
+                unsigned int redirectionCode, const std::string &redirectionPath);
     ServerBlock(const ServerBlock &other);
     ServerBlock &operator=(const ServerBlock &rhs);
     unsigned int getPort() const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,8 +15,8 @@ int main(int ac, char **argv, char **envp)
     try
     {
         Parse a(ac == 2 ? argv[1] : "www/a.conf");
-        Config::createInstance(a.getHttpStr(), a.getServerInfoStrs());
         HttpStatusInfos::initHttpStatusInfos(envp);
+        Config::createInstance(a.getHttpStr(), a.getServerInfoStrs());
         ServerManager sm(Config::getServerInfos());
         sm.run();
     }

--- a/src/parse/BlockBuilder.cpp
+++ b/src/parse/BlockBuilder.cpp
@@ -88,7 +88,6 @@ bool BlockBuilder::tryConvertNumber(const std::string &valueString, bool hasUnit
             return false;
         }
     }
-    result = static_cast<unsigned int>(result);
     return true;
 }
 

--- a/src/parse/HttpBlock.cpp
+++ b/src/parse/HttpBlock.cpp
@@ -1,7 +1,7 @@
 
 #include "HttpBlock.hpp"
 
-HttpBlock::HttpBlock(std::string root, std::vector<std::string> indexs, std::vector<std::string> errorpages,
+HttpBlock::HttpBlock(std::string root, std::vector<std::string> indexs, std::map<int, std::string> errorpages,
                      unsigned int clientMaxBodySize)
     : mRoot(root), mIndexs(indexs), mErrorPages(errorpages), mClientMaxBodySize(clientMaxBodySize)
 {
@@ -37,7 +37,7 @@ const std::vector<std::string> &HttpBlock::getIndexs() const
     return mIndexs;
 }
 
-const std::vector<std::string> &HttpBlock::getErrorPages() const
+const std::map<int, std::string> &HttpBlock::getErrorPages() const
 {
     return mErrorPages;
 }
@@ -61,10 +61,11 @@ std::ostream &operator<<(std::ostream &os, const HttpBlock &httpBlock)
     os << std::endl;
 
     os << "errorPages : ";
-    it = httpBlock.mErrorPages.begin();
-    for (; it != httpBlock.mErrorPages.end(); ++it)
+    std::map<int, std::string>::const_iterator it2 = httpBlock.mErrorPages.begin();
+    for (; it2 != httpBlock.mErrorPages.end(); ++it2)
     {
-        os << *it << " ";
+        os << it2->first << " ";
+        os << it2->second << " ";
     }
     os << std::endl;
 

--- a/src/parse/HttpBlock.cpp
+++ b/src/parse/HttpBlock.cpp
@@ -1,8 +1,8 @@
 
 #include "HttpBlock.hpp"
 
-HttpBlock::HttpBlock(std::string root, std::vector<std::string> indexs, std::map<int, std::string> errorpages,
-                     unsigned int clientMaxBodySize)
+HttpBlock::HttpBlock(const std::string &root, const std::vector<std::string> &indexs,
+                     const std::map<int, std::string> &errorpages, unsigned int clientMaxBodySize)
     : mRoot(root), mIndexs(indexs), mErrorPages(errorpages), mClientMaxBodySize(clientMaxBodySize)
 {
 }

--- a/src/parse/LocationBlock.cpp
+++ b/src/parse/LocationBlock.cpp
@@ -1,6 +1,6 @@
 #include "LocationBlock.hpp"
-LocationBlock::LocationBlock(ServerBlock serverBlock, std::string locationPath, bool isAutoIndex, bool isAllowedGet,
-                             bool isAllowedPost, bool isAllowedDelete)
+LocationBlock::LocationBlock(const ServerBlock &serverBlock, const std::string &locationPath, bool isAutoIndex,
+                             bool isAllowedGet, bool isAllowedPost, bool isAllowedDelete)
     : ServerBlock(serverBlock), mLocationPath(locationPath), mIsAutoIndex(isAutoIndex), mIsAllowedGet(isAllowedGet),
       mIsAllowedPost(isAllowedPost), mIsAllowedDelete(isAllowedDelete)
 {

--- a/src/parse/LocationBlock.cpp
+++ b/src/parse/LocationBlock.cpp
@@ -71,10 +71,11 @@ std::ostream &operator<<(std::ostream &os, const LocationBlock &locationBlock)
     os << std::endl;
 
     os << "errorPages : ";
-    it = locationBlock.mErrorPages.begin();
-    for (; it != locationBlock.mErrorPages.end(); ++it)
+    std::map<int, std::string>::const_iterator it2 = locationBlock.mErrorPages.begin();
+    for (; it2 != locationBlock.mErrorPages.end(); ++it2)
     {
-        os << *it << " ";
+        os << it2->first << " ";
+        os << it2->second << " ";
     }
     os << std::endl;
 

--- a/src/parse/ServerBlock.cpp
+++ b/src/parse/ServerBlock.cpp
@@ -68,10 +68,11 @@ std::ostream &operator<<(std::ostream &os, const ServerBlock &serverBlock)
     os << std::endl;
 
     os << "errorPages : ";
-    it = serverBlock.mErrorPages.begin();
-    for (; it != serverBlock.mErrorPages.end(); ++it)
+    std::map<int, std::string>::const_iterator it2 = serverBlock.mErrorPages.begin();
+    for (; it2 != serverBlock.mErrorPages.end(); ++it2)
     {
-        os << *it << " ";
+        os << it2->first << " ";
+        os << it2->second << " ";
     }
     os << std::endl;
 

--- a/src/parse/ServerBlock.cpp
+++ b/src/parse/ServerBlock.cpp
@@ -1,7 +1,7 @@
 #include "ServerBlock.hpp"
 
-ServerBlock::ServerBlock(HttpBlock httpBlock, unsigned int port, std::string serverName, unsigned int redirectionCode,
-                         std::string redirectionPath)
+ServerBlock::ServerBlock(const HttpBlock &httpBlock, unsigned int port, const std::string &serverName,
+                         unsigned int redirectionCode, const std::string &redirectionPath)
     : HttpBlock(httpBlock), mPort(port), mServerName(serverName), mRedirectionCode(redirectionCode),
       mRedirectionPath(redirectionPath)
 {


### PR DESCRIPTION
### Summary
- #19
- BlockBuilder 클래스의 멤버변수 수정 및 추가(mErrorCodes, mErrorPages)
- BlockBuilder 클래스의 parseConfig() 에서 error_page 지시어 초기화 로직 수정
- BlockBuilder 클래스의 tryConvertNumber() 메소드명 및 로직 수정
- HttpBlock, ServerBlock, LocationBlock 클래스의 생성자 수정
### Description
- 기존의 mErrorPages 멤버변수를 Vector에서 Map으로 수정(ErrorCode - ErrorPagePath)
- mErrorCodes 멤버변수를 추가하여 상기 Map을 초기화하는 용도로 사용
- 기존의 convertNumber()를 mErrorPages를 초기화할 때도 재사용하기 위해 로직 수정
- mErrorPages의 컨테이너가 Vector에서 Map으로 수정됨에 따라 Block 클래스들의 생성자도 Vector에서 Map으로 변경
### TODO
- error_page 지시어가 사용되지 않은 경우, 기본 내장 에러페이지를 보여주는 로직 추가 
