### PR TITLE
[FEAT] Get에서 에러페이지 및 오토인덱스 구현

### DIFF
--- a/include/event/ReadRequestEvent.hpp
+++ b/include/event/ReadRequestEvent.hpp
@@ -7,12 +7,20 @@ class ReadRequestEvent : public AEvent
 {
   private:
     std::string mStringBuffer;
+    std::string mFilePrefix;
+    int mFileSize;
+    int getErrorPageFd(const LocationBlock &lb, int status);
+    int getIndexFd(const LocationBlock &lb, int &stauts);
+    int getFileFd(const LocationBlock &lb, int &status);
+    int getRequestFd(int &status);
+    void setFilePrefix(const LocationBlock &lb);
 
   public:
     ReadRequestEvent(const Server &server, int clientSocket);
     virtual ~ReadRequestEvent();
     virtual int handle();
-    void makeReadFileEvent();
+    void makeResponseEvent(int &status);
+    void makeReadFileEvent(int fd, int &status);
 };
 
 #endif

--- a/include/event/Request.hpp
+++ b/include/event/Request.hpp
@@ -9,6 +9,8 @@ enum eHttpMethod
     E_GET,
     E_POST,
     E_DELETE,
+    E_NOT_IMPLEMENT,
+    E_BAD_REQUEST
 };
 
 enum eRequestLine
@@ -25,14 +27,15 @@ class Request
     std::string mPath;
     std::string mVersion;
     std::map<std::string, std::string> mHeaders;
+    std::string mHost;
     std::string mContent; // 자료형 좀 더 고민
 
     eRequestLine mRequestLine;
     int mStatus;
 
-    void checkMethod(std::stringstream &ss);
-    void checkPath(std::stringstream &ss);
-    void checkHttpVersion(std::stringstream &ss);
+    int checkMethod(std::stringstream &ss);
+    int checkPath(std::stringstream &ss);
+    int checkHttpVersion(std::stringstream &ss);
 
     void parseStartLine(std::string &buffer);
 
@@ -49,6 +52,7 @@ class Request
 
     int getStatus() const;
     const std::map<std::string, std::string> &getHeaders() const;
+    const std::string &getHost() const;
     const std::string &getPath() const;
     void clear();
 };

--- a/include/event/Response.hpp
+++ b/include/event/Response.hpp
@@ -12,6 +12,7 @@ class Response
   public:
     Response();
     void init(int httpStatusCode, int contentLength);
+    void addHead(const std::string &key, const std::string &value);
     const std::string &getStartLine() const;
     const std::string &getHead() const;
 };

--- a/include/parse/LocationBlock.hpp
+++ b/include/parse/LocationBlock.hpp
@@ -21,6 +21,7 @@ class LocationBlock : public ServerBlock
   public:
     LocationBlock(const ServerBlock &serverBlock, const std::string &locationPath, bool isAutoIndex, bool isAllowedGet,
                   bool isAllowedPost, bool isAllowedDelete);
+    LocationBlock(const ServerBlock &serverBlock);
     LocationBlock &operator=(const LocationBlock &rhs);
     const std::string &getLocationPath() const;
     bool isAutoIndex() const;

--- a/include/server/HttpStatusInfos.hpp
+++ b/include/server/HttpStatusInfos.hpp
@@ -21,6 +21,7 @@ class HttpStatusInfos
     static const std::string &getHttpReason(const int statusCode);
     static const std::string &getHttpErrorPage(const int statusCode);
     static const std::string &getWebservRoot();
+    static const std::string makeAutoIndexPage(const std::string &path);
 };
 
 #endif

--- a/include/server/Server.hpp
+++ b/include/server/Server.hpp
@@ -23,7 +23,6 @@ class Server
     void addServerInfo(const ServerInfo &serverInfo);
     void listen();
     const LocationBlock getLocationBlockForRequest(const std::string &host, const std::string &path) const;
-    // const std::vector<std::string> getFilePath(const std::string &host, std::string path, bool &isFolder) const;
 
     // Debugging - TODO : 추후 삭제
     friend std::ostream &operator<<(std::ostream &os, const Server &serverb);

--- a/include/server/Server.hpp
+++ b/include/server/Server.hpp
@@ -22,7 +22,8 @@ class Server
     const std::vector<ServerInfo> &getServerInfos() const;
     void addServerInfo(const ServerInfo &serverInfo);
     void listen();
-    const std::vector<std::string> getFilePath(const std::string &host, std::string path, bool &isFolder) const;
+    const LocationBlock getLocationBlockForRequest(const std::string &host, const std::string &path) const;
+    // const std::vector<std::string> getFilePath(const std::string &host, std::string path, bool &isFolder) const;
 
     // Debugging - TODO : 추후 삭제
     friend std::ostream &operator<<(std::ostream &os, const Server &serverb);

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -1,9 +1,11 @@
 #ifndef UTIL_HPP
 #define UTIL_HPP
 
+#include <fcntl.h>
 #include <fstream>
 #include <string>
 
+int nonBlockOpen(const char *str, int flag);
 bool isWhiteSpace(const char c);
 std::string trim(const std::string &str);
 void trimLine(std::string &line);

--- a/src/event/ReadRequestEvent.cpp
+++ b/src/event/ReadRequestEvent.cpp
@@ -3,7 +3,7 @@
 #include "Kqueue.hpp"
 #include "ReadFileEvent.hpp"
 #include "WriteEvent.hpp"
-#include <fcntl.h>
+#include "util.hpp"
 #include <sstream>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -28,7 +28,7 @@ int ReadRequestEvent::getIndexFd(const LocationBlock &lb, int &status)
         filePath = mFilePrefix + *indexIt;
         if (stat(filePath.c_str(), &fileInfo) == 0)
         {
-            int fd = open(filePath.c_str(), O_RDONLY);
+            int fd = nonBlockOpen(filePath.c_str(), O_RDONLY);
             if (fd != -1)
             {
                 mFileSize = fileInfo.st_size;
@@ -72,12 +72,11 @@ int ReadRequestEvent::getErrorPageFd(const LocationBlock &lb, int status)
     {
         if (S_ISREG(fileInfo.st_mode))
         {
-            int fd = open(errorPagePath.c_str(), O_RDONLY);
+            int fd = nonBlockOpen(errorPagePath.c_str(), O_RDONLY);
             if (fd == -1)
             {
                 return -1;
             }
-            fcntl(fd, F_SETFL, O_NONBLOCK, FD_CLOEXEC);
             mFileSize = fileInfo.st_size;
             return fd;
         }
@@ -94,7 +93,7 @@ int ReadRequestEvent::getFileFd(const LocationBlock &lb, int &status)
     {
         if (S_ISREG(fileInfo.st_mode))
         {
-            int fd = open(filePath.c_str(), O_RDONLY);
+            int fd = nonBlockOpen(filePath.c_str(), O_RDONLY);
             if (fd != -1)
             {
                 mFileSize = fileInfo.st_size;

--- a/src/event/ReadRequestEvent.cpp
+++ b/src/event/ReadRequestEvent.cpp
@@ -2,11 +2,13 @@
 #include "HttpStatusInfos.hpp"
 #include "Kqueue.hpp"
 #include "ReadFileEvent.hpp"
+#include "WriteEvent.hpp"
 #include <fcntl.h>
+#include <sstream>
 #include <sys/stat.h>
 #include <unistd.h>
 
-ReadRequestEvent::ReadRequestEvent(const Server &server, int clientSocket) : AEvent(server, clientSocket)
+ReadRequestEvent::ReadRequestEvent(const Server &server, int clientSocket) : AEvent(server, clientSocket), mFileSize(0)
 {
 }
 
@@ -14,47 +16,170 @@ ReadRequestEvent::~ReadRequestEvent()
 {
 }
 
-void ReadRequestEvent::makeReadFileEvent()
+int ReadRequestEvent::getIndexFd(const LocationBlock &lb, int &status)
 {
-    std::map<std::string, std::string> header = mRequest.getHeaders();
-    const std::string &path = mRequest.getPath();
+    const std::vector<std::string> &indexs = lb.getIndexs();
+    std::vector<std::string>::const_iterator indexIt = indexs.begin();
     std::string filePath;
-    bool isFolder;
-
-    const std::vector<std::string> filePaths = mServer.getFilePath(header["Host"], path, isFolder);
-    // todo debug용
-    std::vector<std::string>::const_iterator it = filePaths.begin();
-    for (; it != filePaths.end(); ++it)
-    {
-        std::cout << "filepath : " << HttpStatusInfos::getWebservRoot() << *it << std::endl;
-    }
-    int size = filePaths.size();
-
     struct stat fileInfo;
-    for (int i = 0; i < size; ++i)
-    {
-        filePath = HttpStatusInfos::getWebservRoot() + filePaths[i];
-        if (stat(filePath.c_str(), &fileInfo) == 0) // 파일이 존재 // 권한 체크 문제는 어떻게 처리할지 테스트 필요
-        {
-            if (S_ISREG(fileInfo.st_mode)) // 파일이면
-            {
-                int fd = open(filePath.c_str(), O_RDONLY);
-                fcntl(fd, F_SETFL, O_NONBLOCK, FD_CLOEXEC);
 
-                struct kevent newEvent;
-                EV_SET(&newEvent, fd, EVFILT_READ, EV_ADD, 0, 0,
-                       new ReadFileEvent(mServer, mClientSocket, fd, fileInfo.st_size, 200));
-                Kqueue::addEvent(newEvent);
-                break;
-            }
-            else if (S_ISDIR(fileInfo.st_mode)) // 디렉토리이면
+    for (; indexIt != indexs.end(); ++indexIt)
+    {
+        filePath = mFilePrefix + *indexIt;
+        if (stat(filePath.c_str(), &fileInfo) == 0)
+        {
+            int fd = open(filePath.c_str(), O_RDONLY);
+            if (fd != -1)
             {
-                ; // 디렉토리 로직 추가
+                mFileSize = fileInfo.st_size;
+                return fd;
+            }
+            else if (status == 200)
+            {
+                status = 403; // 권한없음
             }
         }
+        else if (status == 200)
+        {
+            status = 404;
+        }
+    }
+    // 반복문을 돌았는데 열리는 index 파일이 없으면
+    if (lb.isAutoIndex() == true)
+    {
+        status = 200;
+        return -1; // todo 오토인덱스 구현해야함
     }
 
-    mRequest.clear();
+    return getErrorPageFd(lb, status);
+}
+// todo 고민중 매개변수를 (const std::map<int, std::string> &errorPages, const std::string &root, int status)
+// 로 변경할지
+int ReadRequestEvent::getErrorPageFd(const LocationBlock &lb, int status)
+{
+    struct stat fileInfo;
+    const std::map<int, std::string> &errorPages = lb.getErrorPages();
+    std::map<int, std::string>::const_iterator it = errorPages.find(status);
+    if (it == errorPages.end())
+    {
+        return -1;
+    }
+
+    std::string errorPagePath = HttpStatusInfos::getWebservRoot() + lb.getRoot() + it->second;
+    // todo debug 용
+    std::cout << "errorPagePath : " << errorPagePath << std::endl;
+    if (stat(errorPagePath.c_str(), &fileInfo) == 0)
+    {
+        if (S_ISREG(fileInfo.st_mode))
+        {
+            int fd = open(errorPagePath.c_str(), O_RDONLY);
+            if (fd == -1)
+            {
+                return -1;
+            }
+            fcntl(fd, F_SETFL, O_NONBLOCK, FD_CLOEXEC);
+            mFileSize = fileInfo.st_size;
+            return fd;
+        }
+    }
+    return -1;
+}
+
+int ReadRequestEvent::getFileFd(const LocationBlock &lb, int &status)
+{
+    struct stat fileInfo;
+    std::string filePath = mFilePrefix;
+
+    if (stat(filePath.c_str(), &fileInfo) == 0)
+    {
+        if (S_ISREG(fileInfo.st_mode))
+        {
+            int fd = open(filePath.c_str(), O_RDONLY);
+            if (fd != -1)
+            {
+                mFileSize = fileInfo.st_size;
+                return fd;
+            }
+            status = 403; // 권한없음
+            return getErrorPageFd(lb, status);
+        }
+        else if (S_ISDIR(fileInfo.st_mode))
+        {
+            status = 301;
+            return -1;
+        }
+    }
+    status = 404;
+    return getErrorPageFd(lb, status);
+}
+
+void ReadRequestEvent::setFilePrefix(const LocationBlock &lb)
+{
+    std::string requestPath = mRequest.getPath();
+    requestPath.replace(0, lb.getLocationPath().length(), lb.getRoot());
+
+    // // 환경변수로 저장된 웹서브 root를 요청된 path 앞에 삽입
+    mFilePrefix = HttpStatusInfos::getWebservRoot() + requestPath;
+}
+
+int ReadRequestEvent::getRequestFd(int &status)
+{
+    if (status >= 400)
+    {
+        // 여기서 errorPage용 lb을 만들어 줘야 할듯
+        return getErrorPageFd(LocationBlock(mServer.getServerInfos()[0].getServerBlock()), status);
+    }
+
+    assert(status == 200);
+    std::string requestPath = mRequest.getPath();
+    const LocationBlock lb = mServer.getLocationBlockForRequest(mRequest.getHost(), requestPath);
+    setFilePrefix(lb);
+    // 요청이 폴더로 들어온 경우
+    if (requestPath[requestPath.size() - 1] == '/')
+    {
+        return getIndexFd(lb, status);
+    }
+    // 요정이 파일로 들어온 경우
+    return getFileFd(lb, status);
+}
+
+void ReadRequestEvent::makeResponseEvent(int &status)
+{
+    struct kevent newEvent;
+    std::string responseBody;
+    if (status != 200)
+    {
+        responseBody = HttpStatusInfos::getHttpErrorPage(status);
+    }
+    else
+    {
+        responseBody = HttpStatusInfos::makeAutoIndexPage(mFilePrefix);
+        // todo test
+        std::cout << "auto : " << mFilePrefix << std::endl;
+    }
+    mResponse.init(status, responseBody.length());
+    if (status == 301)
+    {
+        std::ostringstream oss;
+        oss << "http://" << mRequest.getHost() << mRequest.getPath() << "/";
+        // todo Debug
+        std::cout << "301 path : " << oss.str() << std::endl;
+        // todo Debug
+        mResponse.addHead("Location", oss.str());
+    }
+    std::string message = mResponse.getStartLine() + CRLF + mResponse.getHead() + CRLF + CRLF + responseBody;
+    EV_SET(&newEvent, mClientSocket, EVFILT_WRITE, EV_ADD, 0, 0, new WriteEvent(mServer, mClientSocket, message));
+    Kqueue::addEvent(newEvent);
+}
+
+// makeResponseEvent() -> 메소드 명 수정?
+void ReadRequestEvent::makeReadFileEvent(int fd, int &status)
+{
+    struct kevent newEvent;
+    // assert(mFileSize != 0);
+    EV_SET(&newEvent, mClientSocket, EVFILT_WRITE, EV_ADD, 0, 0,
+           new ReadFileEvent(mServer, mClientSocket, fd, mFileSize, status));
+    Kqueue::addEvent(newEvent);
 }
 
 int ReadRequestEvent::handle()
@@ -63,14 +188,12 @@ int ReadRequestEvent::handle()
     int n = read(mClientSocket, buffer, BUFFER_SIZE);
     if (n < 0)
     {
-        // 읽기를 실패 -> client에 500번대를 응답
         close(mClientSocket);
         delete this;
         return EVENT_CONTINUE;
     }
     else if (n == 0)
     {
-        // 디스커넥트 소켓 로직 필요
         close(mClientSocket);
         delete this;
         return EVENT_FINISH;
@@ -78,15 +201,17 @@ int ReadRequestEvent::handle()
     mStringBuffer.append(buffer, n);
     mRequest.parse(mStringBuffer);
     int status = mRequest.getStatus();
-    if (status >= 400)
+    if (status >= 200)
     {
-        Kqueue::deleteEvent(mClientSocket, EVFILT_READ);
-        delete this;
-        return EVENT_FINISH;
-    }
-    else if (status >= 200)
-    {
-        makeReadFileEvent();
+        int fd = getRequestFd(status);
+        if (fd == -1)
+        {
+            makeResponseEvent(status);
+        }
+        else
+        {
+            makeReadFileEvent(fd, status);
+        }
         Kqueue::deleteEvent(mClientSocket, EVFILT_READ);
         delete this;
         return EVENT_FINISH;

--- a/src/event/Response.cpp
+++ b/src/event/Response.cpp
@@ -1,5 +1,6 @@
 #include "Response.hpp"
 #include "HttpStatusInfos.hpp"
+#include <sstream>
 
 Response::Response()
 {
@@ -7,8 +8,19 @@ Response::Response()
 
 void Response::init(int httpStatusCode, int contentLength)
 {
-    mStartLine = "HTTP/1.1 " + std::to_string(httpStatusCode) + " " + HttpStatusInfos::getHttpReason(httpStatusCode);
-    mHead = "Content-Length: " + std::to_string(contentLength);
+    std::ostringstream oss;
+    oss << "HTTP/1.1 " << httpStatusCode << " " << httpStatusCode;
+    mStartLine = oss.str();
+
+    oss.str("");
+    oss.clear();
+    oss << "Content-Length: " << contentLength;
+    mHead = oss.str();
+}
+
+void Response::addHead(const std::string &key, const std::string &value)
+{
+    mHead += CRLF + key + ": " + value;
 }
 
 const std::string &Response::getStartLine() const

--- a/src/parse/BlockBuilder.cpp
+++ b/src/parse/BlockBuilder.cpp
@@ -156,7 +156,15 @@ void BlockBuilder::updateConfig(const std::string &key, const std::string &value
 {
     if (key == "root")
     {
-        mRoot = "/" + value + "/";
+        mRoot = value;
+        if (mRoot[0] != '/')
+        {
+            mRoot = "/" + mRoot;
+        }
+        if (mRoot[mRoot.size() - 1] != '/')
+        {
+            mRoot = mRoot + "/";
+        }
     }
     else if (key == "index")
     {
@@ -185,7 +193,7 @@ void BlockBuilder::updateConfig(const std::string &key, const std::string &value
             {
                 for (size_t i = 0; i < mErrorCodes.size(); ++i)
                 {
-                    mErrorPages[mErrorCodes[i]] = HttpStatusInfos::getWebservRoot() + value;
+                    mErrorPages[mErrorCodes[i]] = value;
                 }
                 isMadeErrorPages = true;
                 mErrorCodes.clear();

--- a/src/parse/LocationBlock.cpp
+++ b/src/parse/LocationBlock.cpp
@@ -5,6 +5,11 @@ LocationBlock::LocationBlock(const ServerBlock &serverBlock, const std::string &
       mIsAllowedPost(isAllowedPost), mIsAllowedDelete(isAllowedDelete)
 {
 }
+LocationBlock::LocationBlock(const ServerBlock &serverBlock)
+    : ServerBlock(serverBlock), mLocationPath(""), mIsAutoIndex(false), mIsAllowedGet(true), mIsAllowedPost(true),
+      mIsAllowedDelete(true)
+{
+}
 
 LocationBlock &LocationBlock::operator=(const LocationBlock &rhs)
 {

--- a/src/server/HttpStatusInfos.cpp
+++ b/src/server/HttpStatusInfos.cpp
@@ -1,4 +1,5 @@
 #include "HttpStatusInfos.hpp"
+#include <dirent.h>
 #include <iostream>
 
 std::map<int, std::string> HttpStatusInfos::mHttpStatusReasons;
@@ -62,6 +63,31 @@ void HttpStatusInfos::setWebservRoot(char **envp)
     {
         throw std::runtime_error("webserv는 환경변수 WEBSERV_ROOT가 필요합니다.");
     }
+}
+
+const std::string HttpStatusInfos::makeAutoIndexPage(const std::string &path)
+{
+    DIR *dir;
+    struct dirent *ent;
+    std::string html =
+        "<html><head><title>Index of " + path + "</title></head><body><h1>Index of " + path + "</h1><ul>";
+
+    if ((dir = opendir(path.c_str())) != NULL)
+    {
+        while ((ent = readdir(dir)) != NULL)
+        {
+            html += "<li><a href=\"" + std::string(ent->d_name) + "\">" + std::string(ent->d_name) + "</a></li>";
+        }
+        closedir(dir);
+    }
+    else
+    {
+        // 디렉토리를 열 수 없을 경우
+        html += "<p>Cannot open directory.</p>";
+    }
+
+    html += "</ul></body></html>";
+    return html;
 }
 
 const std::string &HttpStatusInfos::getHttpReason(const int statusCode)

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -12,7 +12,9 @@ Server::Server(const ServerInfo &serverInfo) : mSocket(0), mPort(serverInfo.getS
 Server::~Server()
 {
     if (mSocket != 0)
+    {
         close(mSocket);
+    }
 }
 
 void Server::listen()
@@ -66,23 +68,9 @@ void Server::addServerInfo(const ServerInfo &serverInfo)
     mServerInfos.push_back(serverInfo);
 }
 
-// 이걸 받는 response에서 해줘야 할것
-// 1. 반환값 iterator를 돌면서 open할 수 있는지 확인
-// 	  - 할 수 있으면 읽고 response 객체에 저장
-// 2. 다 돌았는데 open 할 수 있는게 없다!
-//    - autoindex, 301이 있음
-//    - 파일이면 같은이름의 폴더가 있는지 확인(opendir)
-//    - 있으면 301 없으면 404
-//    - 폴더이면 autoindex가 있는지 확인
-//    - on이면 autoindex, off 이면 404
-const std::vector<std::string> Server::getFilePath(const std::string &host, std::string path, bool &isFolder) const
+const LocationBlock Server::getLocationBlockForRequest(const std::string &host, const std::string &path) const
 {
     assert(path != "");
-    std::vector<std::string> indexsPath;
-    std::vector<std::string> filePath;
-    std::string root;
-    std::string locationPath;
-
     std::vector<ServerInfo>::const_iterator serverIt = mServerInfos.begin();
     ServerInfo targetServerInfo = *serverIt;
     ++serverIt;
@@ -96,57 +84,16 @@ const std::vector<std::string> Server::getFilePath(const std::string &host, std:
     }
 
     std::vector<LocationBlock>::const_iterator locIt = targetServerInfo.getLocationBlocks().begin();
-    // 지금 location은 길이순으로 정렬이 되어 있는 상태
 
+    // 지금 location은 길이순으로 정렬이 되어 있는 상태
     for (; locIt != targetServerInfo.getLocationBlocks().end(); ++locIt)
     {
         if (path.find(locIt->getLocationPath()) == 0)
         {
-            locationPath = locIt->getLocationPath();
-            indexsPath = locIt->getIndexs();
-            root = locIt->getRoot();
-            break;
+            return *locIt;
         }
     }
-
-    // 서버 블록을 따라 간다.
-    if (locIt == targetServerInfo.getLocationBlocks().end())
-    {
-        indexsPath = targetServerInfo.getServerBlock().getIndexs();
-        root = targetServerInfo.getServerBlock().getRoot();
-        locationPath = "";
-    }
-
-    // 폴더를 요청한 경우
-    // index위치 벡터를 보내줌
-
-    // todo locationpath가 시작부분이 /로 시작한다고 가정함
-    assert(path[0] == '/');
-
-    // locationPath가 빈칸인 경우
-    // 일단 앞에 붙이는것으로 처리함
-    size_t pos = path.find(locationPath);
-    assert(pos == 0);
-    path.replace(pos, locationPath.length(), root);
-
-    // 폴더의 경우
-    if (path[path.size() - 1] == '/')
-    {
-        isFolder = true;
-        std::vector<std::string>::iterator indexIt = indexsPath.begin();
-        for (; indexIt != indexsPath.end(); ++indexIt)
-        {
-            *indexIt = path + *indexIt;
-        }
-        return indexsPath;
-    }
-    // 파일의 경우
-    else
-    {
-        isFolder = false;
-        filePath.push_back(path);
-        return filePath;
-    }
+    return LocationBlock(targetServerInfo.getServerBlock());
 }
 
 // Debugging TODO - 추후 삭제

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,5 +1,16 @@
 #include "util.hpp"
 
+int nonBlockOpen(const char *str, int flag)
+{
+    int fd = open(str, flag);
+    if (fd == -1)
+    {
+        return -1;
+    }
+    fcntl(fd, F_SETFL, O_NONBLOCK, FD_CLOEXEC);
+    return fd;
+}
+
 std::string trim(const std::string &str)
 {
     std::size_t first = str.find_first_not_of(" ");

--- a/www/a.conf
+++ b/www/a.conf
@@ -1,13 +1,14 @@
 http {
   server { # main server
-		error_page 303;
-    listen       8080; ##port(server name 먼저 확인), IP+port(요청 IP와 port대조), IP(default port)
+    listen       8088; ##port(server name 먼저 확인), IP+port(요청 IP와 port대조), IP(default port)
     server_name  localhost; ## 요청 host header와 일치하는 서버네임, 선행 와일드카드, 후행 와일드카드, 정규식, 기본서버
-    root         www;
+    root         /www/;
+  	error_page 404 50x.html;
 
 	location  / {
-  	error_page 404 /404.html;
+  	error_page 404 50x.html;
 		index index.html index.htm;
+		autoindex on;
 		limit_except deny GET;
 		limit_except deny POST;
 	  }

--- a/www/asdf/50x.html
+++ b/www/asdf/50x.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Error</title>
+<style>
+html { color-scheme: light dark; }
+body { width: 35em; margin: 0 auto;
+font-family: Tahoma, Verdana, Arial, sans-serif; }
+</style>
+</head>
+<body>
+<h1>An error occurred.</h1>
+<p>Sorry, the page you are looking for is currently unavailable.<br/>
+Please try again later.</p>
+<p>If you are the system administrator of this resource then you should check
+the error log for details.</p>
+<p><em>Faithfully yours, nginx.</em></p>
+</body>
+</html>

--- a/www/asdf/index.html
+++ b/www/asdf/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to webserv!</title>
+<style>
+html { color-scheme: light dark; }
+body { width: 35em; margin: 0 auto;
+font-family: Tahoma, Verdana, Arial, sans-serif; }
+</style>
+</head>
+<body>
+<h1>Welcome to webserv!</h1>
+<p>If you see this page, the webserv web server is successfully installed and
+working. Further configuration is required.</p>
+
+<p><em>Thank you for using webserv.</em></p>
+</body>
+</html>

--- a/www/autoIndex/hi/50x.html
+++ b/www/autoIndex/hi/50x.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Error</title>
+<style>
+html { color-scheme: light dark; }
+body { width: 35em; margin: 0 auto;
+font-family: Tahoma, Verdana, Arial, sans-serif; }
+</style>
+</head>
+<body>
+<h1>An error occurred.</h1>
+<p>Sorry, the page you are looking for is currently unavailable.<br/>
+Please try again later.</p>
+<p>If you are the system administrator of this resource then you should check
+the error log for details.</p>
+<p><em>Faithfully yours, nginx.</em></p>
+</body>
+</html>

--- a/www/new-year/index.html
+++ b/www/new-year/index.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<link href="style.css" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Stylish&display=swap" rel="stylesheet">
+    <title>Happy New Year</title>
+    <style>
+      body {
+        height: 100vh;
+        background: radial-gradient(
+          ellipse at bottom,
+          #172c43 0%,
+          #090a0f 100%
+        );
+        overflow: hidden;
+      }
+      .snow {
+        width: 7px;
+        height: 7px;
+        opacity: 0;
+        background: #fff;
+        border-radius: 50%;
+        animation: snowFall 10s linear infinite;
+      }
+      @keyframes snowFall {
+        0% {
+          opacity: 0;
+          transform: translateY(0);
+        }
+        20% {
+          opacity: 1;
+          transform: translate(-15px, 20vh);
+        }
+        40% {
+          opacity: 1;
+          transform: translate(15px, 40vh);
+        }
+        60% {
+          opacity: 1;
+          transform: translate(-15px, 60vh);
+        }
+        80% {
+          opacity: 1;
+          transform: translate(0px, 80vh);
+        }
+        100% {
+          opacity: 1;
+          transform: translateY(100vh);
+        }
+      }
+      .snow:nth-of-type(2n) {
+        width: 8px;
+        height: 8px;
+        animation-delay: 0s;
+        animation-duration: 15s;
+        border: 1px solid #fff;
+        box-shadow: 0 0 10px #fff, 0 0 20px #fff, 0 0 30px #fff, 0 0 40px #fff,
+          0 0 50px #fff;
+      }
+      .snow:nth-of-type(2n + 1) {
+        animation-delay: 10s;
+        animation-duration: 15s;
+        box-shadow: 0 0 10px #fff, 0 0 20px #fff, 0 0 30px #fff, 0 0 40px #fff,
+          0 0 50px #fff;
+      }
+      .snow:nth-of-type(3n) {
+        animation-delay: 5s;
+        animation-duration: 15s;
+      }
+
+      .happy-new-year {
+        font-family: "Stylish", sans-serif;
+        font-size: 100px;
+        color: #facd05; 
+        text-align: center;
+        position: absolute;
+        top: 30%; 
+        width: 100%;
+      }
+     @media screen and (max-width: 600px) {
+	.happy-new-year {
+		font-size: 50px;
+		top: 30%
+	}
+    }
+    </style>
+  </head>
+  <body>
+    <script>
+      function createSnow() {
+        const el = document.createElement("div");
+        el.className = "snow";
+        el.style.marginLeft = randomPositon() + "px";
+        document.body.appendChild(el);
+      }
+      function randomPositon() {
+        return Math.floor(Math.random() * window.innerWidth);
+      }
+      for (let i = 0; i < 90; i++) {
+        createSnow();
+      }
+    </script>
+    <div class="happy-new-year">🐲 새해 복 많이 받으세요 🐲</div>
+  </body>
+</html>


### PR DESCRIPTION
### Summary
- Server에 있는 getFilePath 로직을 readRequsetEvent로 옮겼습니다.
- Get 요청 시 파일이 없을 때 error 페이지를 응답합니다.
- Get 요청 시 폴더를 요청한 경우 경우에 따라 적절하게 응답합니다.
### Description
#### Server에 있는 getFilePath 로직을 readRequsetEvent로 옮겼습니다.
- Server에는 단순히 요청 경로에 부분일치하는 loctationBlock을 반환하는 getLocationBlockForRequest()을 추가했습니다.
- 이렇게 변경하게 된 이유는 getFilePath을 작성할 당시에는 부분일치하는 locationBlock의 인덱스 파일 벡터만 필요하다고 생각했습니다.
- 하지만 error_page, autoIndex등 더 필요한 부분이 있어서 맞는 locationBlock을 반환하게 변경했습니다.
#### Get 요청 시 파일이 없을 때 error 페이지를 응답합니다.
- 파일이 없으면 conf 설정에 따라 에러 페이지를 보여줍니다. conf 파일이 없을 때는 하드코딩한 에러 html 문자열로 응답합니다
#### Get 요청 시 폴더를 요청한 경우 경우에 따라 적절하게 응답합니다.
- 폴더 경로를 요청하는 경우 Index 지시어에 써있는 파일로 응답하거나 지시어가 없는 경우index.html를 찾습니다.
- 파일을 못찾을 경우 autoIndex 지시어에 따라 autoIndex 페이지를 반환하거나 에러 페이지를 반환합니다.
### TODO
- mime type 헤더 적용
- 잘못된 요청일 경우 클라이언트 소켓 끊기(400, 501)
- Connection: close 일때 끊어주기 
