### PR TITLE
[fix]: response 헤더 추가하는 로직 수정

### DIFF
--- a/include/event/ReadFileEvent.hpp
+++ b/include/event/ReadFileEvent.hpp
@@ -12,9 +12,11 @@ class ReadFileEvent : public AEvent
     int mReadSize;
     int mHttpStatusCode;
     std::string mBody;
+    const std::string mMimeType;
 
   public:
-    ReadFileEvent(const Server &server, int clientSocket, int fileFd, int fileSize, int mHttpStatusCode);
+    ReadFileEvent(const Server &server, int clientSocket, int fileFd, int fileSize, int mHttpStatusCode,
+                  const std::string &mimeType);
     virtual ~ReadFileEvent();
     virtual int handle();
 };

--- a/src/event/ReadFileEvent.cpp
+++ b/src/event/ReadFileEvent.cpp
@@ -5,9 +5,10 @@
 #include <sys/event.h>
 #include <unistd.h>
 
-ReadFileEvent::ReadFileEvent(const Server &server, int clientSocket, int fileFd, int fileSize, int httpStatusCode)
+ReadFileEvent::ReadFileEvent(const Server &server, int clientSocket, int fileFd, int fileSize, int httpStatusCode,
+                             const std::string &mimeType)
     : AEvent(server, clientSocket), mFileFd(fileFd), mFileSize(fileSize), mReadSize(0), mHttpStatusCode(httpStatusCode),
-      mBody("")
+      mBody(""), mMimeType(mimeType)
 {
 }
 
@@ -33,6 +34,7 @@ int ReadFileEvent::handle()
     {
         close(mFileFd);
         mResponse.init(mHttpStatusCode, mReadSize);
+        mResponse.addHead("Content-Type", mMimeType);
         std::string message = mResponse.getStartLine() + CRLF + mResponse.getHead() + CRLF CRLF + mBody;
 
         struct kevent newEvent;

--- a/src/event/ReadRequestEvent.cpp
+++ b/src/event/ReadRequestEvent.cpp
@@ -207,7 +207,7 @@ void ReadRequestEvent::makeReadFileEvent(int fd, int &status)
     struct kevent newEvent;
     // assert(mFileSize != 0);
     EV_SET(&newEvent, mClientSocket, EVFILT_WRITE, EV_ADD, 0, 0,
-           new ReadFileEvent(mServer, mClientSocket, fd, mFileSize, status));
+           new ReadFileEvent(mServer, mClientSocket, fd, mFileSize, status, mMimeType));
     Kqueue::addEvent(newEvent);
 }
 

--- a/src/event/Response.cpp
+++ b/src/event/Response.cpp
@@ -9,7 +9,7 @@ Response::Response()
 void Response::init(int httpStatusCode, int contentLength)
 {
     std::ostringstream oss;
-    oss << "HTTP/1.1 " << httpStatusCode << " " << httpStatusCode;
+    oss << "HTTP/1.1 " << httpStatusCode << " " << HttpStatusInfos::getHttpReason(httpStatusCode);
     mStartLine = oss.str();
 
     oss.str("");


### PR DESCRIPTION
### Summary
- response 헤더 추가하는 로직을 수정했습니다
- HTTP/1.1 200 200 처럼 상태코드, 사유가 아닌 상태 코드가 두 번 나오는 버그 수정했습니다.
### Description
#### response 헤더 추가하는 로직을 수정했습니다
##### 원인 
- 이전의 로직은 status 200이 아닐때만  content-type이 response 헤더에 추가되는 문제가 있었습니다.
- 이유는 
-  src/event/ReadRequestEvent.cpp에서 236 ~ 243줄
``` C++
int fd = getRequestFd(status);
if (fd == -1)
 {
    makeResponseEvent(status);
}
else
{
    makeReadFileEvent(fd, status);
}
 ```
- makeReadFileEvent
 ```C++
 void ReadRequestEvent::makeReadFileEvent(int fd, int &status)
    {
    struct kevent newEvent;
    // assert(mFileSize != 0);
    EV_SET(&newEvent, mClientSocket, EVFILT_WRITE, EV_ADD, 0, 0,
           new ReadFileEvent(mServer, mClientSocket, fd, mFileSize, status));
    Kqueue::addEvent(newEvent);`
    }
```
- 여기서 fd != -1이 아니면 makeReadFileEvent로 들어가는데 이 로직에서는 
- makeResponseEvent(status) 내부의 
``` C++
mResponse.addHead("Content-Type", mMimeType);
```
- 이 로직이 없기 때문에 정상적으로 file fd가 열린 경우는 reponse의 헤더에 Content-Type이 추가가 안되는 오류가 있었습니다.

##### 해결방법
```C++
ReadFileEvent::ReadFileEvent(const Server &server, int clientSocket, int fileFd, int fileSize, int httpStatusCode,
                             const std::string &mimeType)
```
- readFileEvent 생성자에서 mimeType을 받고 readFileEvent에서 response을 생성할때  reponse의 헤더에 Content-Type이 추가가 되도록 수정했습니다.
#### HTTP/1.1 200 200 처럼 상태코드, 사유가 아닌 상태 코드가 두 번 나오는 버그 수정했습니다.
##### 원인
```C++
    oss << "HTTP/1.1 " << httpStatusCode << " " << httpStatusCode;
```
##### 해결
```C++
    oss << "HTTP/1.1 " << httpStatusCode << " " << HttpStatusInfos::getHttpReason(httpStatusCode);
```
### TODO
- 모든 이벤트의 조상인 AEvent의 response을 사용을 못하는것 같습니다.
- 이 클래스를 사용하는 방법을 생각해봐야 할 것 같습니다. #51 
