### PR TITLE
refact: response 클래스를 활용하도록 Response, WriteEvent, ReadFileEvent 변경

### DIFF
--- a/include/event/AEvent.hpp
+++ b/include/event/AEvent.hpp
@@ -12,14 +12,15 @@
 class AEvent
 {
   protected:
+    const Server &mServer;
     Response mResponse;
     Request mRequest;
-    const Server &mServer;
     int mClientSocket;
 
   public:
     AEvent(const Server &server);
     AEvent(const Server &server, int clientSocket);
+    AEvent(const Server &server, const Response &response, int clientSocket);
     virtual ~AEvent();
     virtual void handle() = 0;
 };

--- a/include/event/ReadFileEvent.hpp
+++ b/include/event/ReadFileEvent.hpp
@@ -10,13 +10,10 @@ class ReadFileEvent : public AEvent
     char mBuffer[BUFFER_SIZE];
     int mFileSize;
     int mReadSize;
-    int mHttpStatusCode;
     std::string mBody;
-    const std::string mMimeType;
 
   public:
-    ReadFileEvent(const Server &server, int clientSocket, int fileFd, int fileSize, int mHttpStatusCode,
-                  const std::string &mimeType);
+    ReadFileEvent(const Server &server, const Response &response, int clientSocket, int fileFd, int fileSize);
     virtual ~ReadFileEvent();
     virtual void handle();
 };

--- a/include/event/Response.hpp
+++ b/include/event/Response.hpp
@@ -8,11 +8,14 @@ class Response
   private:
     std::string mStartLine;
     std::string mHead;
+    std::string mBody;
 
   public:
     Response();
     void init(int httpStatusCode, int contentLength);
     void addHead(const std::string &key, const std::string &value);
+    void setBody(const std::string &body);
+    const std::string toStr() const;
     const std::string &getStartLine() const;
     const std::string &getHead() const;
 };

--- a/include/event/WriteEvent.hpp
+++ b/include/event/WriteEvent.hpp
@@ -10,10 +10,11 @@ class WriteEvent : public AEvent
     std::string mMessage;
     int mWriteSize;
     int mResponseSize;
-		int mStatus;
+    int mStatus;
 
   public:
-    WriteEvent(const Server &server, int clientSocket, std::string message, int status);
+    // WriteEvent(const Server &server, int clientSocket, std::string message, int status);
+    WriteEvent(const Server &server, const Response &response, int clientSocket);
     virtual ~WriteEvent();
     virtual void handle();
 };

--- a/include/event/WriteEvent.hpp
+++ b/include/event/WriteEvent.hpp
@@ -10,7 +10,6 @@ class WriteEvent : public AEvent
     std::string mMessage;
     int mWriteSize;
     int mResponseSize;
-    int mStatus;
 
   public:
     // WriteEvent(const Server &server, int clientSocket, std::string message, int status);

--- a/src/event/AEvent.cpp
+++ b/src/event/AEvent.cpp
@@ -8,6 +8,11 @@ AEvent::AEvent(const Server &server, int clientSocket) : mServer(server), mClien
 {
 }
 
+AEvent::AEvent(const Server &server, const Response &response, int clientSocket)
+    : mServer(server), mResponse(response), mClientSocket(clientSocket)
+{
+}
+
 AEvent::~AEvent()
 {
 }

--- a/src/event/ReadFileEvent.cpp
+++ b/src/event/ReadFileEvent.cpp
@@ -29,7 +29,6 @@ void ReadFileEvent::handle()
     {
         close(mFileFd);
         mResponse.setBody(mBody);
-        std::string message = mResponse.toStr();
 
         struct kevent newEvent;
         EV_SET(&newEvent, mClientSocket, EVFILT_WRITE, EV_ADD, 0, 0, new WriteEvent(mServer, mResponse, mClientSocket));

--- a/src/event/Response.cpp
+++ b/src/event/Response.cpp
@@ -23,6 +23,18 @@ void Response::addHead(const std::string &key, const std::string &value)
     mHead += CRLF + key + ": " + value;
 }
 
+void Response::setBody(const std::string &body)
+{
+    mBody = body;
+}
+
+const std::string Response::toStr() const
+{
+    assert(mStartLine.size() != 0);
+    assert(mHead.size() != 0);
+    return mStartLine + CRLF + mHead + CRLF + CRLF + mBody;
+}
+
 const std::string &Response::getStartLine() const
 {
     return mStartLine;

--- a/src/event/WriteEvent.cpp
+++ b/src/event/WriteEvent.cpp
@@ -2,8 +2,10 @@
 #include "Kqueue.hpp"
 #include "ReadRequestEvent.hpp"
 
-WriteEvent::WriteEvent(const Server &server, int clientSocket, std::string message, int status)
-    : AEvent(server, clientSocket), mMessage(message), mWriteSize(0), mResponseSize(message.size()), mStatus(status)
+// mResponseSize(response.toStr().size()) 로 한 이유는 소켓에 write() 할 string의 길이가 필요하기 때문
+WriteEvent::WriteEvent(const Server &server, const Response &response, int clientSocket)
+    : AEvent(server, response, clientSocket), mMessage(response.toStr()), mWriteSize(0),
+      mResponseSize(response.toStr().size())
 {
 }
 

--- a/src/event/WriteEvent.cpp
+++ b/src/event/WriteEvent.cpp
@@ -28,12 +28,13 @@ void WriteEvent::handle()
     mWriteSize += n;
     if (mWriteSize == mResponseSize)
     {
-        if (mStatus == 400 || mStatus == 501)
-        {
-            close(mClientSocket);
-            delete this;
-            return;
-        }
+        // todo connectionType 구현 필요
+        // if (mResponse.getHead().find("Connection"))
+        // {
+        //     close(mClientSocket);
+        //     delete this;
+        //     return;
+        // }
         Kqueue::deleteEvent(mClientSocket, EVFILT_WRITE);
         struct kevent newEvent;
         EV_SET(&newEvent, mClientSocket, EVFILT_READ, EV_ADD, 0, 0, new ReadRequestEvent(mServer, mClientSocket));


### PR DESCRIPTION
### Summary
-  response 클래스를 활용하도록 Response, WriteEvent, ReadFileEvent 변경했습니다. #51 
### Description
#### Response 메서드 추가했습니다.
-> mResponse.toStr() 구현했습니다.
-> mResponse.addBody(const std::string &body) 구현했습니다.
#### WriteEvent 클래스 변경했습니다.
-> 생성자 WriteEvent(const Server &server, const Response &response, int clientSocket);로 변경했습니다.
#### ReadFileEvent 클래스 변경했습니다.
-> 생성자 ReadFileEvent(const Server &server, const Response &response, int clientSocket, int fileFd, int fileSize);로 변경했습니다.
-> response을 ReadFileEvent 내부에서는 본문만 만들도록 수정(밖에서 시작줄, 헤더를 만든 response을 받음) 했습니다.
### TODO
- 테스트 추가 필요 합니다.
- connectionType 구현 필요합니다.
