### PR TITLE
[FEAT] 헤더 Content-length와 Connection 구현

### DIFF
--- a/include/event/ConnectionEnum.hpp
+++ b/include/event/ConnectionEnum.hpp
@@ -1,0 +1,10 @@
+#ifndef CONNECTIONENUM_HPP
+#define CONNECTIONENUM_HPP
+
+enum eConnectionStatus
+{
+    KEEP_ALIVE,
+    CONNECTION_CLOSE,
+};
+
+#endif

--- a/include/event/Request.hpp
+++ b/include/event/Request.hpp
@@ -20,13 +20,18 @@ enum eRequestLine
     E_REQUEST_CONTENTS
 };
 
+struct CaseInsensitiveCompare
+{
+    bool operator()(const std::string &a, const std::string &b) const;
+};
+
 class Request
 {
   private:
     eHttpMethod mMethod;
     std::string mPath;
     std::string mVersion;
-    std::map<std::string, std::string> mHeaders;
+    std::map<std::string, std::string, CaseInsensitiveCompare> mHeaders;
     std::string mHost;
     std::string mContent; // 자료형 좀 더 고민
 
@@ -51,7 +56,7 @@ class Request
     void parse(std::string &buffer);
 
     int getStatus() const;
-    const std::map<std::string, std::string> &getHeaders() const;
+    const std::map<std::string, std::string, CaseInsensitiveCompare> &getHeaders() const;
     const std::string &getHost() const;
     const std::string &getPath() const;
     void clear();

--- a/include/event/Request.hpp
+++ b/include/event/Request.hpp
@@ -1,6 +1,7 @@
 #ifndef REQUEST_HPP
 #define REQUEST_HPP
 
+#include "ConnectionEnum.hpp"
 #include <map>
 #include <string>
 
@@ -39,6 +40,7 @@ class Request
 
     eRequestLine mRequestLine;
     int mStatus;
+    eConnectionStatus mConnectionStatus;
 
     int checkMethod(std::stringstream &ss);
     int checkPath(std::stringstream &ss);
@@ -62,6 +64,7 @@ class Request
     const std::string &getHost() const;
     const std::string &getPath() const;
     const std::string &getBody() const;
+    eConnectionStatus getConnectionStatus() const;
     void clear();
 };
 

--- a/include/event/Request.hpp
+++ b/include/event/Request.hpp
@@ -34,6 +34,8 @@ class Request
     std::map<std::string, std::string, CaseInsensitiveCompare> mHeaders;
     std::string mHost;
     std::string mContent; // 자료형 좀 더 고민
+    std::string mBody;
+    unsigned int mContentLength;
 
     eRequestLine mRequestLine;
     int mStatus;
@@ -59,6 +61,7 @@ class Request
     const std::map<std::string, std::string, CaseInsensitiveCompare> &getHeaders() const;
     const std::string &getHost() const;
     const std::string &getPath() const;
+    const std::string &getBody() const;
     void clear();
 };
 

--- a/include/event/Response.hpp
+++ b/include/event/Response.hpp
@@ -1,6 +1,7 @@
 #ifndef RESPONSE_HPP
 #define RESPONSE_HPP
 
+#include "ConnectionEnum.hpp"
 #include <iostream>
 
 class Response
@@ -9,6 +10,7 @@ class Response
     std::string mStartLine;
     std::string mHead;
     std::string mBody;
+    eConnectionStatus mConnectionStatus;
 
   public:
     Response();
@@ -18,6 +20,8 @@ class Response
     const std::string toStr() const;
     const std::string &getStartLine() const;
     const std::string &getHead() const;
+    eConnectionStatus getConnectionStatus() const;
+    void setConnectionClose();
 };
 
 #endif

--- a/src/event/ReadRequestEvent.cpp
+++ b/src/event/ReadRequestEvent.cpp
@@ -193,6 +193,10 @@ void ReadRequestEvent::makeResponseEvent(int &status)
     }
     assert(mMimeType.size() != 0);
     mResponse.addHead("Content-Type", mMimeType);
+    if (mRequest.getConnectionStatus() == CONNECTION_CLOSE)
+    {
+        mResponse.setConnectionClose();
+    }
     assert(responseBody.size() != 0);
     mResponse.setBody(responseBody);
     EV_SET(&newEvent, mClientSocket, EVFILT_WRITE, EV_ADD, 0, 0, new WriteEvent(mServer, mResponse, mClientSocket));
@@ -205,6 +209,10 @@ void ReadRequestEvent::makeReadFileEvent(int fd, int &status)
     // todo filesize가 맞는지 확인 필요
     mResponse.init(status, mFileSize);
     mResponse.addHead("Content-Type", mMimeType);
+    if (mRequest.getConnectionStatus() == CONNECTION_CLOSE)
+    {
+        mResponse.setConnectionClose();
+    }
     EV_SET(&newEvent, mClientSocket, EVFILT_WRITE, EV_ADD, 0, 0,
            new ReadFileEvent(mServer, mResponse, mClientSocket, fd, mFileSize));
     Kqueue::addEvent(newEvent);

--- a/src/event/Request.cpp
+++ b/src/event/Request.cpp
@@ -3,6 +3,19 @@
 #include "util.hpp"
 #include <sstream>
 
+bool CaseInsensitiveCompare::operator()(const std::string &a, const std::string &b) const
+{
+    size_t minLength = std::min(a.length(), b.length());
+    for (size_t i = 0; i < minLength; ++i)
+    {
+        if (tolower(a[i]) < tolower(b[i]))
+            return true;
+        if (tolower(a[i]) > tolower(b[i]))
+            return false;
+    }
+    return a.length() < b.length();
+}
+
 Request::Request()
     : mMethod(E_GET), mPath(""), mVersion("HTTP/1.1"), mHost(""), mContent(""), mRequestLine(E_START_LINE), mStatus(0)
 {
@@ -191,7 +204,7 @@ void Request::clear()
     mStatus = 0;
 }
 
-const std::map<std::string, std::string> &Request::getHeaders() const
+const std::map<std::string, std::string, CaseInsensitiveCompare> &Request::getHeaders() const
 {
     return mHeaders;
 }

--- a/src/event/Response.cpp
+++ b/src/event/Response.cpp
@@ -2,7 +2,7 @@
 #include "HttpStatusInfos.hpp"
 #include <sstream>
 
-Response::Response()
+Response::Response() : mConnectionStatus(KEEP_ALIVE)
 {
 }
 
@@ -43,4 +43,15 @@ const std::string &Response::getStartLine() const
 const std::string &Response::getHead() const
 {
     return mHead;
+}
+
+eConnectionStatus Response::getConnectionStatus() const
+{
+    return mConnectionStatus;
+}
+
+void Response::setConnectionClose()
+{
+    mConnectionStatus = CONNECTION_CLOSE;
+    addHead("Connection", "close");
 }

--- a/src/event/WriteEvent.cpp
+++ b/src/event/WriteEvent.cpp
@@ -28,13 +28,12 @@ void WriteEvent::handle()
     mWriteSize += n;
     if (mWriteSize == mResponseSize)
     {
-        // todo connectionType 구현 필요
-        // if (mResponse.getHead().find("Connection"))
-        // {
-        //     close(mClientSocket);
-        //     delete this;
-        //     return;
-        // }
+        if (mResponse.getConnectionStatus() == CONNECTION_CLOSE)
+        {
+            close(mClientSocket);
+            delete this;
+            return;
+        }
         Kqueue::deleteEvent(mClientSocket, EVFILT_WRITE);
         struct kevent newEvent;
         EV_SET(&newEvent, mClientSocket, EVFILT_READ, EV_ADD, 0, 0, new ReadRequestEvent(mServer, mClientSocket));


### PR DESCRIPTION
### Summary
- Content-length가 있을 시 body를 파싱합니다.
- Connection이 close일 때 소켓 연결을 닫습니다.
### Description
- Request 클래스 헤더 map에 operator() 로직을 추가해서 대소문자 구분 없이 map에 저장합니다. 
- Connection 헤더가 close로 들어오면 요청을 처리한 후 응답 후 소켓을 닫습니다.
- 400, 501일 때도  응답한 후 소켓을 닫습니다. 
- 소켓을 닫을 때는 응답헤더에 Connection: close를 추가해서 보냅니다.
### TODO
- chunked data 바디 파싱
