### PR TITLE
feat: client_max_body_size 0 ~ 2147483647로 범위를 지정

### DIFF
--- a/include/parse/BlockBuilder.hpp
+++ b/include/parse/BlockBuilder.hpp
@@ -11,13 +11,6 @@
 #include <string>
 #include <vector>
 
-enum unit
-{
-    E_KILLO = 1000,
-    E_MEGA = 1000000,
-    E_GIGA = 100000000,
-};
-
 enum blockType
 {
     E_HTTP,
@@ -29,6 +22,13 @@ class BlockBuilder
 {
 
   private:
+    enum unit
+    {
+        E_KILLO = 1000,
+        E_MEGA = 1000000,
+        E_GIGA = 100000000,
+        E_CLIENT_MAX_BODY_SIZE = 2147483647,
+    };
     std::string mRoot;
     std::vector<std::string> mIndexs;
     std::vector<unsigned int> mErrorCodes;

--- a/include/parse/BlockBuilder.hpp
+++ b/include/parse/BlockBuilder.hpp
@@ -24,9 +24,9 @@ class BlockBuilder
   private:
     enum unit
     {
-        E_KILLO = 1000,
-        E_MEGA = 1000000,
-        E_GIGA = 100000000,
+        E_KILLO = 1024,
+        E_MEGA = 1024 * 1024,
+        E_GIGA = 1024 * 1024 * 1024,
         E_CLIENT_MAX_BODY_SIZE = 2147483647,
     };
     std::string mRoot;

--- a/src/parse/BlockBuilder.cpp
+++ b/src/parse/BlockBuilder.cpp
@@ -35,13 +35,11 @@ std::string BlockBuilder::reduceMultipleSpaces(std::string token)
     return cleanedToken;
 }
 
-// 함수 만드는 방법
 bool BlockBuilder::tryConvertNumber(const std::string &valueString, bool hasUnit, unsigned int &result)
 {
     char *checkPtr;
     unsigned long value;
 
-    // 음수인 경우
     if (valueString.c_str()[0] == '-')
     {
         return false;


### PR DESCRIPTION
### Summary
- client_max_body_size 0 ~ 2147483647로 범위를 지정했습니다. #8 
- EUnit 값 수정했습니다.
### Description
#### client_max_body_size 0 ~ 2147483647로 범위를 지정했습니다.
- nginx상에는 max값이 정의 되어 있지 않지만 비슷한 서버인 아파치의 경우 2GB까지로 최댓값이 정의가 되어있습니다.
- 최댓값을 정의 하는것이 에러 탐색하기 용이할것 같아서 아파치의 경우를 참고했습니다.
#### EUnit 값 수정했습니다.
- killo를 1000으로 정의 했었는데
- 실제 nginx에서는 1024로 되어있어서 수정했습니다.
- https://hg.nginx.org/nginx/file/default/src/core/ngx_parse.c
### TODO
- 실제로 readRequestEvent에서 client_max_body_size가 잘 작동하는지 확인이 필요합니다
### GIST
- [tryConvertNumber.cpp 설명](https://gist.github.com/guune/2002165d0eecfaf084ebe5b349c83774)
