### PR TITLE
[FEAT] Request 클래스에서 파일 업로드  크기 제한과 허용 메소드 반영하는 로직 작성

### DIFF
--- a/include/event/AEvent.hpp
+++ b/include/event/AEvent.hpp
@@ -14,7 +14,6 @@ class AEvent
   protected:
     const Server &mServer;
     Response mResponse;
-    Request mRequest;
     int mClientSocket;
 
   public:

--- a/include/event/ReadRequestEvent.hpp
+++ b/include/event/ReadRequestEvent.hpp
@@ -6,6 +6,7 @@
 class ReadRequestEvent : public AEvent
 {
   private:
+    Request mRequest;
     enum
     {
         NOT_FOUND = -1,

--- a/include/event/Request.hpp
+++ b/include/event/Request.hpp
@@ -2,6 +2,7 @@
 #define REQUEST_HPP
 
 #include "ConnectionEnum.hpp"
+#include "Server.hpp"
 #include <map>
 #include <string>
 
@@ -29,17 +30,24 @@ struct CaseInsensitiveCompare
 class Request
 {
   private:
+    const Server &mServer;
     eHttpMethod mMethod;
     std::string mPath;
     std::string mVersion;
+
     std::map<std::string, std::string, CaseInsensitiveCompare> mHeaders;
     std::string mHost;
     std::string mBody;
-    unsigned int mContentLength;
+    size_t mContentLength;
 
     eRequestLine mRequestLine;
     int mStatus;
     eConnectionStatus mConnectionStatus;
+
+    unsigned int mClientMaxBodySize;
+    bool mIsAllowedGet;
+    bool mIsAllowedPost;
+    bool mIsAllowedDelete;
 
     int checkMethod(std::stringstream &ss);
     int checkPath(std::stringstream &ss);
@@ -54,7 +62,7 @@ class Request
     void parseRequestContent(std::string &buffer);
 
   public:
-    Request();
+    Request(const Server &server);
     ~Request();
     void parse(std::string &buffer);
 
@@ -64,7 +72,6 @@ class Request
     const std::string &getPath() const;
     const std::string &getBody() const;
     eConnectionStatus getConnectionStatus() const;
-    void clear();
 };
 
 #endif

--- a/src/event/ReadRequestEvent.cpp
+++ b/src/event/ReadRequestEvent.cpp
@@ -9,7 +9,7 @@
 #include <unistd.h>
 
 ReadRequestEvent::ReadRequestEvent(const Server &server, int clientSocket)
-    : AEvent(server, clientSocket), mFileSize(0), mMimeType("text/html")
+    : AEvent(server, clientSocket), mRequest(server), mFileSize(0), mMimeType("text/html")
 {
 }
 
@@ -158,7 +158,7 @@ int ReadRequestEvent::getRequestFd(int &status)
 
     assert(status == 200);
     std::string requestPath = mRequest.getPath();
-    const LocationBlock lb = mServer.getLocationBlockForRequest(mRequest.getHost(), requestPath);
+    const LocationBlock &lb = mServer.getLocationBlockForRequest(mRequest.getHost(), requestPath);
     setFilePrefix(lb);
     // 요청이 폴더로 들어온 경우
     if (requestPath[requestPath.size() - 1] == '/')

--- a/src/event/Request.cpp
+++ b/src/event/Request.cpp
@@ -122,7 +122,7 @@ int Request::storeHeaderLine(const std::string &line)
         return -1;
     }
 
-    headerKey = trim(line.substr(0, pos));
+    headerKey = line.substr(0, pos);
     if (mHeaders.find(headerKey) != mHeaders.end())
     {
         mStatus = 400; // Bad Request

--- a/src/event/Request.cpp
+++ b/src/event/Request.cpp
@@ -20,8 +20,8 @@ bool CaseInsensitiveCompare::operator()(const std::string &a, const std::string 
     return a.length() < b.length();
 }
 
-Request::Request()
-    : mMethod(E_GET), mPath(""), mVersion("HTTP/1.1"), mHost(""), mBody(""), mContentLength(0),
+Request::Request(const Server &server)
+    : mServer(server), mMethod(E_GET), mPath(""), mVersion("HTTP/1.1"), mHost(""), mBody(""), mContentLength(0),
       mRequestLine(E_START_LINE), mStatus(0), mConnectionStatus(KEEP_ALIVE)
 {
 }
@@ -65,7 +65,7 @@ int Request::checkMethod(std::stringstream &ss)
 int Request::checkPath(std::stringstream &ss)
 {
     ss >> mPath;
-    if (mPath == "")
+    if (mPath.empty())
     {
         mStatus = 400; // Bad Request
         return -1;
@@ -173,12 +173,21 @@ void Request::parseRequestHeader(std::string &buffer)
         }
         mHost = mHeaders["Host"];
 
-        if (mHeaders.find("Connection") != mHeaders.end())
+        if (mHeaders.find("Connection") != mHeaders.end() && mHeaders["Connection"] == "close")
         {
-            if (mHeaders["Connection"] == "close")
-            {
-                mConnectionStatus = CONNECTION_CLOSE;
-            }
+            mConnectionStatus = CONNECTION_CLOSE;
+        }
+
+        const LocationBlock &lb = mServer.getLocationBlockForRequest(mHost, mPath);
+        mClientMaxBodySize = lb.getClientMaxBodySize();
+        mIsAllowedGet = lb.isAllowedGet();
+        mIsAllowedPost = lb.isAllowedPost();
+        mIsAllowedDelete = lb.isAllowedDelete();
+        if ((mMethod == E_DELETE && mIsAllowedDelete == false) || (mMethod == E_GET && mIsAllowedGet == false) ||
+            (mMethod == E_POST && mIsAllowedPost == false))
+        {
+            mStatus = 405;
+            return;
         }
 
         if (mHeaders.find("Content-Length") != mHeaders.end())
@@ -190,6 +199,7 @@ void Request::parseRequestHeader(std::string &buffer)
             mRequestLine = E_REQUEST_CONTENTS;
             return;
         }
+
         mStatus = 200;
     }
 }
@@ -203,7 +213,7 @@ void Request::parseRequestContent(std::string &buffer)
         mStatus = 200;
     }
     // ContentLength보다 더 많이 들어왔을 때
-    else if (mBody.size() > mContentLength)
+    else if (mBody.size() > mContentLength || mBody.size() > mClientMaxBodySize)
     {
         mStatus = 400;
     }
@@ -232,15 +242,6 @@ void Request::parse(std::string &buffer)
 int Request::getStatus() const
 {
     return mStatus;
-}
-
-void Request::clear()
-{
-    mRequestLine = E_START_LINE;
-    mPath = "";
-    mHeaders.clear();
-    mBody = "";
-    mStatus = 0;
 }
 
 const std::map<std::string, std::string, CaseInsensitiveCompare> &Request::getHeaders() const

--- a/src/server/HttpStatusInfos.cpp
+++ b/src/server/HttpStatusInfos.cpp
@@ -48,8 +48,8 @@ void HttpStatusInfos::initHttpErrorPages()
                            "<center><h1>404 Not Found</h1></center>" CRLF;
     mHttpErrorPages[405] = "<html>" CRLF "<head><title>405 Not Allowed</title></head>" CRLF "<body>" CRLF
                            "<center><h1>405 Not Allowed</h1></center>" CRLF;
-    mHttpErrorPages[501] = "<html>" CRLF "<head><title>405 Not Allowed</title></head>" CRLF "<body>" CRLF
-                           "<center><h1>405 Not Allowed</h1></center>" CRLF;
+    mHttpErrorPages[501] = "<html>" CRLF "<head><title>501 Not Implemented</title></head>" CRLF "<body>" CRLF
+                           "<center><h1>501 Not Implemented</h1></center>" CRLF;
     mHttpErrorPages[503] = "<html>" CRLF "<head><title>503 Service Temporarily Unavailable</title></head>" CRLF
                            "<body>" CRLF "<center><h1>503 Service Temporarily Unavailable</h1></center>" CRLF;
 }

--- a/www/a.conf
+++ b/www/a.conf
@@ -9,7 +9,7 @@ http {
   	error_page 404 50x.html;
 		index index.html index.htm;
 		autoindex on;
-		limit_except deny GET;
+		# limit_except deny GET;
 		limit_except deny POST;
 	  }
 	}


### PR DESCRIPTION
### Summary
- Request 클래스에서 파일 업로드 크기 제한인 client_max_body_size와 limit_except deny POST와 같은 허용 메소드 지시어를 구하는 로직을 작성했습니다.
### Description
- AEvent의 멤버 변수인  Request 클래스를  ReadRequestEvent에서만 읽기 때문에 멤버 변수를 옮겼습니다.
- getLocationBlockForRequest 메소드를 이용해서 헤더를 파싱한 후 client_max_body_size와 허용 메소드를 알 수 있게 했습니다. 바디를 읽을 때 client_max_body_size 보다 더 많이 읽게되면 Bad Request를 응답합니다.
- 수정 사항이 몇가지 있습니다.
  - 헤더 키값에 앞뒤 공백이 있을 때와 없을 때가 다른 헤더라고 판단해서 trim을 뺐습니다. (ngnix 테스트 중 "Host :"을 넣었을 때 Bad Request 응답)
  - 501 에러페이지 HTML이 잘못되어 있어 수정했습니다.
  - conf 파일에  get 요청이 limit 되어 있어 원활한 테스트를 위해 주석 처리했습니다. 
### TODO
- 
