### PR TITLE
feat: chunked request 기능 추가

### DIFF
--- a/include/event/Request.hpp
+++ b/include/event/Request.hpp
@@ -2,6 +2,7 @@
 #define REQUEST_HPP
 
 #include "ConnectionEnum.hpp"
+#include <cstdlib>
 #include <map>
 #include <string>
 
@@ -18,7 +19,8 @@ enum eRequestLine
 {
     E_START_LINE,
     E_REQUEST_HEADER,
-    E_REQUEST_CONTENTS
+    E_REQUEST_CONTENTS,
+    E_CHUNKED_CONTENTS
 };
 
 struct CaseInsensitiveCompare
@@ -41,6 +43,12 @@ class Request
     int mStatus;
     eConnectionStatus mConnectionStatus;
 
+    unsigned int mChunkedSize;
+    std::string mChunkedData;
+    bool mIsChunkedData; // true일 때가 내용이 들어올 차례
+                         // bool mFirstCRLF;
+		unsigned int mClientMaxBodySize;
+
     int checkMethod(std::stringstream &ss);
     int checkPath(std::stringstream &ss);
     int checkHttpVersion(std::stringstream &ss);
@@ -52,6 +60,8 @@ class Request
 
     void parseRequestHeader(std::string &buffer);
     void parseRequestContent(std::string &buffer);
+    bool checkChunkedData(void);
+    void parseChunkedContent(std::string &buffer);
 
   public:
     Request();

--- a/include/event/Request.hpp
+++ b/include/event/Request.hpp
@@ -34,9 +34,9 @@ class Request
   private:
     enum
     {
-        NEED_SIZE = -1,
-				LAST_CHUNK = 0
+        NO_SIZE = 0
     };
+
     const Server &mServer;
     eHttpMethod mMethod;
     std::string mPath;
@@ -51,7 +51,7 @@ class Request
     int mStatus;
     eConnectionStatus mConnectionStatus;
 
-    int mChunkedSize;
+    unsigned long mChunkedSize;
     unsigned int mClientMaxBodySize;
     bool mIsAllowedGet;
     bool mIsAllowedPost;

--- a/include/event/Request.hpp
+++ b/include/event/Request.hpp
@@ -2,8 +2,8 @@
 #define REQUEST_HPP
 
 #include "ConnectionEnum.hpp"
-#include <cstdlib>
 #include "Server.hpp"
+#include <cstdlib>
 #include <map>
 #include <string>
 
@@ -48,13 +48,11 @@ class Request
 
     unsigned int mChunkedSize;
     std::string mChunkedData;
-    bool mIsChunkedData; // true일 때가 내용이 들어올 차례
-                         // bool mFirstCRLF;
-		unsigned int mClientMaxBodySize;
+    bool mIsChunkedData;
+    unsigned int mClientMaxBodySize;
     bool mIsAllowedGet;
     bool mIsAllowedPost;
     bool mIsAllowedDelete;
-
 
     int checkMethod(std::stringstream &ss);
     int checkPath(std::stringstream &ss);

--- a/include/event/Request.hpp
+++ b/include/event/Request.hpp
@@ -47,7 +47,6 @@ class Request
     eConnectionStatus mConnectionStatus;
 
     unsigned int mChunkedSize;
-    std::string mChunkedData;
     bool mIsChunkedData;
     unsigned int mClientMaxBodySize;
     bool mIsAllowedGet;

--- a/include/event/Request.hpp
+++ b/include/event/Request.hpp
@@ -32,6 +32,11 @@ struct CaseInsensitiveCompare
 class Request
 {
   private:
+    enum
+    {
+        NEED_SIZE = -1,
+				LAST_CHUNK = 0
+    };
     const Server &mServer;
     eHttpMethod mMethod;
     std::string mPath;
@@ -46,8 +51,7 @@ class Request
     int mStatus;
     eConnectionStatus mConnectionStatus;
 
-    unsigned int mChunkedSize;
-    bool mIsChunkedData;
+    int mChunkedSize;
     unsigned int mClientMaxBodySize;
     bool mIsAllowedGet;
     bool mIsAllowedPost;

--- a/src/event/Request.cpp
+++ b/src/event/Request.cpp
@@ -227,8 +227,6 @@ void Request::parseChunkedContent(std::string &buffer)
 {
     std::stringstream ss;
     size_t pos = 0;
-    // 플래그의 상태로 사이즈 받을지, 데이터 받을지 확인
-    //  플래그가 -1이면 사이즈 받을 차례, 0 <=면 본문 받을 차례
 
     if (mChunkedSize == NEED_SIZE && (pos = buffer.find(CRLF)) != std::string::npos)
     {

--- a/src/event/Request.cpp
+++ b/src/event/Request.cpp
@@ -231,13 +231,18 @@ void Request::parseChunkedContent(std::string &buffer)
     {
         if (mIsChunkedData)
         {
-            mChunkedData = buffer.substr(0, pos);
-            if (mChunkedSize != mChunkedData.size())
+            std::string chunkedData = buffer.substr(0, pos);
+            if (mChunkedSize != chunkedData.size())
             {
                 mStatus = 400;
                 return;
             }
-            mBody += mChunkedData;
+            mBody += chunkedData;
+            if (mBody.size() > mClientMaxBodySize)
+            {
+                mStatus = 400;
+                return;
+            }
             mIsChunkedData = false;
         }
         else
@@ -253,7 +258,7 @@ void Request::parseChunkedContent(std::string &buffer)
             }
             if (mChunkedSize == 0)
             {
-                if (mBody.size() == 0 || mBody.size() > mClientMaxBodySize)
+                if (mBody.size() == 0)
                 {
                     mStatus = 400;
                     return;

--- a/src/event/Request.cpp
+++ b/src/event/Request.cpp
@@ -251,7 +251,7 @@ void Request::parseChunkedContent(std::string &buffer)
         }
         buffer = buffer.substr(pos + 2);
     }
-    if (mChunkedSize != NEED_SIZE && !buffer.empty() && static_cast<unsigned long>(mChunkedSize) <= buffer.size() + 2)
+    else if (mChunkedSize != NEED_SIZE && static_cast<unsigned long>(mChunkedSize) <= buffer.size() + 2)
     {
         if (buffer.substr(mChunkedSize, 2) != CRLF)
         {


### PR DESCRIPTION
### Summary
- 요청 헤더: header parse에서  "Transfer-Encoding : chunked" 항목이 있을 시, chunked data를 병합하는 로직으로 들어갑니다. #60 
### Description
- Request class의 enum(eRequestLine)에 E_CHUNKED_CONTENTS가 추가되었습니다. 
- 그 다음 chunked 메세지를 순차적으로 받습니다.
- 메세지는 chunked size, chunked data 순으로 번갈아서 들어옵니다.
- 이 순서가 잘못되거나, 해당 내용이 없을 경우 에러로 mStatus를 설정하고 리턴합니다.
- chunked size는 16진수로 수신되고, 10진수로 변환 후 저장합니다.
- size가 유효하지 않은 범위이거나, buffer의 size 인덱스 직후에 CRLF가 아닐 시 에러를 리턴합니다.
- 정상적인 buffer로 확인되면 mBody에 해당 내용을 더해서 추가합니다. 
- 마지막 종료 메세지는 chunked size가 0, 읽을 buffer 내용이 없는 상태로 마무리 됩니다.정상종료 될 때 모든 내용 차곡차곡 mBody에 담겨져 있습니다.
- 기존의 header와 body를 parse 하는 로직을 차용했다가 위키에 내용에 CRLF 들어갈 수 있다는 제보를 반영해 내용에도 CRLF가 정상적으로 들어가도록 수정했습니다.
### TODO 
- chunked 는 POST 메소드로 만들었기 때문에 example.com으로 테스트하기가 어려웠습니다. 유사한 작동의 테스트가 필요합니다.
- CRLF가 내용에 있을 시, 줄바꿈된 상태로 들어가기 때문에 출력물이 조금 보기 어렵습니다. 역시 작동의 테스트가 필요합니다.
### GIST
- [chunked](https://gist.github.com/sngsho/b2cff945532e8bbb3257ba1b731b194a)