### PR TITLE
[FEAT] ReadRequestEvent 클래스 로직 수정

### DIFF
--- a/include/event/ReadRequestEvent.hpp
+++ b/include/event/ReadRequestEvent.hpp
@@ -17,17 +17,19 @@ class ReadRequestEvent : public AEvent
     std::string mMimeType;
     int getErrorPageFd(const LocationBlock &lb, int status);
     int getIndexFd(const LocationBlock &lb, int &stauts);
-    int getFileFd(const LocationBlock &lb, int &status);
+    int getFileFd(int &status);
     int getRequestFd(int &status);
     void setFilePrefix(const LocationBlock &lb);
-    void setMimeType(const std::string &path);
+    void addMimeTypeHeader(const std::string &path);
+    void makeWriteEvent(int &status);
+    void makeReadFileEvent(int fd);
+
+    void makeResponse(int &status);
 
   public:
     ReadRequestEvent(const Server &server, int clientSocket);
     virtual ~ReadRequestEvent();
     virtual void handle();
-    void makeResponseEvent(int &status);
-    void makeReadFileEvent(int fd, int &status);
 };
 
 #endif

--- a/include/event/Response.hpp
+++ b/include/event/Response.hpp
@@ -14,7 +14,8 @@ class Response
 
   public:
     Response();
-    void init(int httpStatusCode, int contentLength);
+    void setStartLine(int httpStatusCode);
+    void addHead(const std::string &key, const int value);
     void addHead(const std::string &key, const std::string &value);
     void setBody(const std::string &body);
     const std::string toStr() const;

--- a/src/event/Response.cpp
+++ b/src/event/Response.cpp
@@ -6,21 +6,23 @@ Response::Response() : mConnectionStatus(KEEP_ALIVE)
 {
 }
 
-void Response::init(int httpStatusCode, int contentLength)
+void Response::setStartLine(int httpStatusCode)
 {
     std::ostringstream oss;
     oss << "HTTP/1.1 " << httpStatusCode << " " << HttpStatusInfos::getHttpReason(httpStatusCode);
     mStartLine = oss.str();
+}
 
-    oss.str("");
-    oss.clear();
-    oss << "Content-Length: " << contentLength;
-    mHead = oss.str();
+void Response::addHead(const std::string &key, const int value)
+{
+    std::stringstream ss;
+    ss << value;
+    mHead += key + ": " + ss.str() + CRLF;
 }
 
 void Response::addHead(const std::string &key, const std::string &value)
 {
-    mHead += CRLF + key + ": " + value;
+    mHead += key + ": " + value + CRLF;
 }
 
 void Response::setBody(const std::string &body)
@@ -32,7 +34,7 @@ const std::string Response::toStr() const
 {
     assert(mStartLine.size() != 0);
     assert(mHead.size() != 0);
-    return mStartLine + CRLF + mHead + CRLF + CRLF + mBody;
+    return mStartLine + CRLF + mHead + CRLF + mBody;
 }
 
 const std::string &Response::getStartLine() const

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -70,9 +70,12 @@ void Server::addServerInfo(const ServerInfo &serverInfo)
 
 const LocationBlock Server::getLocationBlockForRequest(const std::string &host, const std::string &path) const
 {
-    assert(path != "");
     std::vector<ServerInfo>::const_iterator serverIt = mServerInfos.begin();
     ServerInfo targetServerInfo = *serverIt;
+    if (path == "")
+    {
+        return LocationBlock(targetServerInfo.getServerBlock());
+    }
     ++serverIt;
     for (; serverIt != mServerInfos.end(); ++serverIt)
     {

--- a/www/a.conf
+++ b/www/a.conf
@@ -6,7 +6,7 @@ http {
   	error_page 404 50x.html;
 
 	location  / {
-  	error_page 404 50x.html;
+  	error_page 301 404 50x.html;
 		index index.html index.htm;
 		autoindex on;
 		# limit_except deny GET;


### PR DESCRIPTION
### Summary
- ReadRequestEvent 로직을 수정했습니다.
### Description
- 이전 로직에서는 메세지 파싱에서 에러가 난 경우 error_page를 응답하기 위해 응답 처리 이전에 getErrorPageFd를 호출하고 응답 처리에서 에러가 발생했을 때도 getErrorPageFd를 호출해서 코드의 중복이 있었습니다.
- 로직을 변경해서 상태코드인 status 200일 경우에만 응답 처리를 하고, 200이 아닌 코드면 getErrorPageFd를 호출하게 변경했습니다. status가 200일 때에도 응답처리과정에서 에러가 발생할 수 있기 때문에 이후에도 상태코드가 변경되었는지 if 문을 보고 getErorrPageFd를 호출합니다. [참고](https://gist.github.com/heehoh/d66f0547d5dfeaeb4649ff43fed805fb)
- 요청에서 path가 비어있을 때에 config의 기본 서버로 응답해주기 위해 기본서버를 상속받는 location 블록을 리턴합니다. [참고](https://gist.github.com/heehoh/d5039c0b66c12c2d4f15150a4d6d1430)
- 로직이 변경됨에 따라 메소드명을 수정했습니다. init -> setStartLine 등등
### TODO
- 
