### PR TITLE
[FEAT] 리다이렉션 구현

### DIFF
--- a/include/event/Request.hpp
+++ b/include/event/Request.hpp
@@ -57,6 +57,8 @@ class Request
     bool mIsAllowedPost;
     bool mIsAllowedDelete;
 
+    std::string mRedirectPath;
+
     int checkMethod(std::stringstream &ss);
     int checkPath(std::stringstream &ss);
     int checkHttpVersion(std::stringstream &ss);
@@ -82,6 +84,7 @@ class Request
     const std::string &getPath() const;
     const std::string &getBody() const;
     eConnectionStatus getConnectionStatus() const;
+    const std::string &getRedirectionPath() const;
 };
 
 #endif

--- a/src/event/ReadRequestEvent.cpp
+++ b/src/event/ReadRequestEvent.cpp
@@ -220,7 +220,7 @@ void ReadRequestEvent::makeResponse(int &status)
     }
     else if (status == 307)
     {
-        mResponse.addHead("location", " ㄹㅣ퀘스트에서 해줘야 함"); // todo
+        mResponse.addHead("location", mRequest.getRedirectionPath()); // todo
     }
 
     if (fd == NOT_FOUND)

--- a/src/event/Request.cpp
+++ b/src/event/Request.cpp
@@ -184,12 +184,24 @@ void Request::parseRequestHeader(std::string &buffer)
         mIsAllowedGet = lb.isAllowedGet();
         mIsAllowedPost = lb.isAllowedPost();
         mIsAllowedDelete = lb.isAllowedDelete();
+        if (!lb.getRedirectionPath().empty())
+        {
+            mStatus = 307;
+            mRedirectPath = lb.getRedirectionPath();
+            if (mRedirectPath[0] == '/')
+            {
+                mRedirectPath = "http://" + mHost + mRedirectPath;
+            }
+            return;
+        }
+
         if ((mMethod == E_DELETE && mIsAllowedDelete == false) || (mMethod == E_GET && mIsAllowedGet == false) ||
             (mMethod == E_POST && mIsAllowedPost == false))
         {
             mStatus = 405;
             return;
         }
+
         if (checkChunkedData())
         {
             buffer = buffer.substr(pos + 4);
@@ -210,7 +222,6 @@ void Request::parseRequestHeader(std::string &buffer)
             mRequestLine = E_REQUEST_CONTENTS;
             return;
         }
-
         mStatus = 200;
     }
 }
@@ -340,4 +351,9 @@ const std::string &Request::getBody() const
 eConnectionStatus Request::getConnectionStatus() const
 {
     return mConnectionStatus;
+}
+
+const std::string &Request::getRedirectionPath() const
+{
+    return mRedirectPath;
 }

--- a/src/server/HttpStatusInfos.cpp
+++ b/src/server/HttpStatusInfos.cpp
@@ -31,6 +31,7 @@ void HttpStatusInfos::initHttpStatusReasons()
     mHttpStatusReasons[200] = "OK";
     mHttpStatusReasons[201] = "Created";
     mHttpStatusReasons[301] = "Moved Permanently";
+    mHttpStatusReasons[307] = "Temporary Redirect";
     mHttpStatusReasons[400] = "Bad Request";
     mHttpStatusReasons[404] = "Not Found";
     mHttpStatusReasons[405] = "Method Not Allowed";
@@ -43,6 +44,8 @@ void HttpStatusInfos::initHttpErrorPages()
 {
     mHttpErrorPages[301] = "<html>" CRLF "<head><title>301 Moved Permanently</title></head>" CRLF "<body>" CRLF
                            "<center><h1>301 Moved Permanently</h1></center>" CRLF;
+    mHttpErrorPages[307] = "<html>" CRLF "<head><title>307 Temporary Redirect</title></head>" CRLF "<body>" CRLF
+                           "<center><h1>307 Temporary Redirect</h1></center>" CRLF;
     mHttpErrorPages[400] = "<html>" CRLF "<head><title>400 Bad Request</title></head>" CRLF "<body>" CRLF
                            "<center><h1>400 Bad Request</h1></center>" CRLF;
     mHttpErrorPages[404] = "<html>" CRLF "<head><title>404 Not Found</title></head>" CRLF "<body>" CRLF
@@ -125,8 +128,7 @@ const std::string &HttpStatusInfos::getMimeType(const std::string &type)
     std::map<std::string, std::string>::const_iterator it;
 
     it = mMimeType.find(type);
-    std::cout << "mimetype : " << type << std::endl;
-    // assert(it != mMimeType.end());
+
     if (it == mMimeType.end())
     {
         return mMimeType["html"];

--- a/www/a.conf
+++ b/www/a.conf
@@ -16,5 +16,12 @@ http {
     root /YoupiBanane;
     index youpi.bad_extension;
   }
+	location /hi {
+		return /new-year;
+	}
+	location /hi2 
+	{
+		return http://www.naver.com;
+	}
 	}
 }


### PR DESCRIPTION
### Summary
- location 블록에 return 지시어가 있을 때 해당 블록에 해당하는 요청이 올 때 요청을 리다이렉션 합니다.  #67 
### Description
- request 클래스에 mRedirectPath를 추가시켰고, return 지시어가 있을 때 지시어에 써있는 path를 받고 상태코드를 바꿉니다. 
- ReadRequestEvent에서 status가 307일 때 location 헤더를 추가해서 응답합니다.
