### PR TITLE
fix: Request Chunked Data 반복문 처리 및 탈출 조건 추가, 본문 없을 시 종료 코드 수정

### DIFF
--- a/src/event/Request.cpp
+++ b/src/event/Request.cpp
@@ -239,7 +239,6 @@ bool Request::checkChunkedData(void)
 
 void Request::parseChunkedContent(std::string &buffer)
 {
-    std::stringstream ss;
     size_t pos = 0;
 
     while (1)


### PR DESCRIPTION
### Summary
- Request 클래스의 parseChunkedContent() 에서 받아온 데이터를 모두 처리하기 위해 반복문 및 탈출 조건을 추가
- Request 클래스의 checkChunkedData() 조건식을 한줄로 병합
- mStatus 수정
### Description
- parseChunkedContent()에서 받아온 버퍼를 모두 처리하지 않고 요청을 종료하는 문제점 발견, 반복문을 통해서 버퍼의 내용이 0이 될 때까지 모두 내용을 read하도록 반복문으로 로직을 변경.
- chunked size가 0으로 들어왔을 시, mBody의 내용도 0인, 쓰여진 내용이 없을 시 telnet 테스트에서는 400 에러를 리턴했으나, 테스터에서는 200으로 정상 종료로 처리되어 200으로 수정.
