### PR TITLE
[FEAT] 테스터 통과

### DIFF
--- a/include/event/Request.hpp
+++ b/include/event/Request.hpp
@@ -68,14 +68,14 @@ class Request
     void parseRequestHeader(std::string &buffer);
     void parseRequestContent(std::string &buffer);
     bool checkChunkedData(void);
-    void storeChunkedBody(std::string &buffer);
+    void parseChunkedBody(std::string &buffer);
 
   public:
     typedef HeaderMap::const_iterator MapIt;
     Request();
     ~Request();
     bool tryParse(std::string &buffer);
-    int parseChunkedBody(size_t clientMaxBodySize);
+    // int parseChunkedBody(size_t clientMaxBodySize);
 
     char **getCgiEnvp() const;
     int getStatus() const;

--- a/include/parse/BlockBuilder.hpp
+++ b/include/parse/BlockBuilder.hpp
@@ -31,7 +31,7 @@ class BlockBuilder
     };
     enum defalutValue
     {
-        E_DEFAULT_CLIENT_BODY_SIZE = 1024 * 1024 * 1024,
+        E_DEFAULT_CLIENT_BODY_SIZE = 1024 * 1024,
         E_DEFAULT_LISTEN_PORT = 80,
     };
     static const std::string DEFAULT_ROOT;

--- a/include/server/HttpStatusInfos.hpp
+++ b/include/server/HttpStatusInfos.hpp
@@ -4,6 +4,7 @@
 #define CRLF "\r\n"
 #include <map>
 #include <string>
+#include <vector>
 
 class HttpStatusInfos
 {

--- a/src/event/ReadRequestEvent.cpp
+++ b/src/event/ReadRequestEvent.cpp
@@ -257,10 +257,6 @@ void ReadRequestEvent::handle()
     {
         status = checkRequestError(lb);
     }
-    if (status == OK && mRequest.isChunked() == true)
-    {
-        status = mRequest.parseChunkedBody(lb.getClientMaxBodySize());
-    }
 
     std::string pathExtension;
     std::string path = mRequest.getPath();
@@ -283,7 +279,6 @@ void ReadRequestEvent::handle()
     //     std::cout << lb.getCgiExtension() << "$  " << pathExtension << "  " << status << std::endl;
     if (!lb.getCgiExtension().empty() && status == 200 && lb.getCgiExtension() == pathExtension)
     {
-        std::cout << "CGI" << std::endl;
         int fd[4];
         pipe(fd);     // 0번(부모의 읽기), 1번(자식의 쓰기)
         pipe(fd + 2); // 2번(자식의 읽기), 3번(부모의 쓰기)
@@ -327,7 +322,6 @@ void ReadRequestEvent::handle()
             fcntl(fd[0], F_SETFL, O_NONBLOCK, FD_CLOEXEC);
             fcntl(fd[3], F_SETFL, O_NONBLOCK, FD_CLOEXEC);
 
-            std::cout << "mRequest.getBody() : " << mRequest.getBody().size() << std::endl;
             struct kevent newEvent;
 
             EV_SET(&newEvent, fd[3], EVFILT_WRITE, EV_ADD, 0, 0,

--- a/src/event/Request.cpp
+++ b/src/event/Request.cpp
@@ -205,52 +205,6 @@ void Request::parseChunkedBody(std::string &buffer)
     }
 }
 
-// int Request::parseChunkedBody(size_t clientMaxBodySize)
-// {
-//     size_t parseIndex = 0;
-//     while (1)
-//     {
-//         if (mChunkedSize == NO_SIZE)
-//         {
-//             size_t pos = mChunkedBody.find(CRLF, parseIndex);
-//             assert(pos != std::string::npos);
-//             std::string value = mChunkedBody.substr(parseIndex, pos - parseIndex);
-//             char *endptr;
-//             mChunkedSize = strtol(value.c_str(), &endptr, 16);
-//             if (endptr[0] != '\0')
-//             {
-//                 return BAD_REQUEST;
-//             }
-//             if (mChunkedSize == NO_SIZE)
-//             {
-//                 return OK;
-//             }
-//             parseIndex = pos + 2;
-//             // mChunkedBody.erase(0, pos + 2);
-//         }
-//         else if (mChunkedSize != NO_SIZE /* && (mChunkedSize + 2) <= buffer.size()*/)
-//         {
-//             if (mChunkedBody.substr(parseIndex + mChunkedSize, 2) != CRLF)
-//             {
-//                 return BAD_REQUEST;
-//             }
-//             mBody += mChunkedBody.substr(parseIndex, mChunkedSize);
-//             if (mBody.size() > clientMaxBodySize)
-//             {
-//                 return CONTENT_TOO_LARGE;
-//             }
-//             parseIndex += mChunkedSize + 2;
-//             // mChunkedBody.erase(0, mChunkedSize + 2);
-//             mChunkedSize = NO_SIZE;
-//         }
-//         // else if ((mChunkedSize + 2) > buffer.size() || buffer.size() == 0 ||
-//         //          (mChunkedSize == 0 && (pos = buffer.find(CRLF)) == std::string::npos))
-//         // {
-//         //     return;
-//         // }
-//     }
-// }
-
 void Request::parseRequestContent(std::string &buffer)
 {
     mBody += buffer;

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -43,7 +43,7 @@ void Server::listen()
         throw std::runtime_error("Error Server::listen(): 포트 bind 실패");
     }
     // 클라이언트 연결 대기
-    if (::listen(mSocket, 5) == -1)
+    if (::listen(mSocket, 1000) == -1)
     {
         throw std::runtime_error("Error Server::listen(): listen 실패");
     }

--- a/www/a.conf
+++ b/www/a.conf
@@ -13,6 +13,7 @@ http {
 	  }
 
   location /directory {
+		client_max_body_size 1G;
     root /YoupiBanane;
 		cgi_extension .bla;
 		cgi_path /test-cgi/cgi_tester;


### PR DESCRIPTION
### Summary
- 테스터 66초에 통과했습니다.
### Description
- 이전 코드에서는 chunked data를  0 CRLF CRLF를 만날 때까지 저장하고 이후 unchunked로 변환했는데 바로바로 저장해주는 로직으로 바꿨습니다. 그 결과 테스터가 7분 가량에서 66초로 줄었습니다.
- 멀티유저가 들어오는 테스터에서 요청을 수락하는 게 실패해서 listen의 인자를 5에서 1000으로 바꿨는데 더 유효한 값이 있는지 확인이 필요합니다.
-  
### TODO
- CGI fork하는 로직 메소드로 따로 빼기
- 파일 업로드 CGI 만들기
- DELETE 구현
