### PR TITLE
[REFACT] 상태코드 enum 추가 및 ReadRequsetEvent의 handle에 있던 cgi로직을 메소드로 옮겼습니다.

### DIFF
--- a/include/event/HttpEnum.hpp
+++ b/include/event/HttpEnum.hpp
@@ -10,11 +10,14 @@ enum eConnectionStatus
 enum eHttpStatus
 {
     OK = 200,
-    BAD_REQUEST = 400,
-    NOT_ALLOWED = 405,
-    NOT_IMPLEMENT = 501,
+    MOVED_PERMANENTLY = 301,
     TEMPORARY_REDIRECT = 307,
+    BAD_REQUEST = 400,
+    FORBIDDEN = 403,
+    NOT_FOUND = 404,
+    NOT_ALLOWED = 405,
     CONTENT_TOO_LARGE = 413,
+    NOT_IMPLEMENT = 501,
 };
 
 #endif

--- a/include/event/ReadRequestEvent.hpp
+++ b/include/event/ReadRequestEvent.hpp
@@ -7,10 +7,6 @@ class ReadRequestEvent : public AEvent
 {
   private:
     Request mRequest;
-    enum
-    {
-        NOT_FOUND = -1,
-    };
     std::string mStringBuffer;
     std::string mFilePrefix;
     int mFileSize;
@@ -21,7 +17,7 @@ class ReadRequestEvent : public AEvent
     int getFileFd(int &status);
     int getRequestFd(int &status);
     void setFilePrefix(const LocationBlock &lb);
-    void addMimeTypeHeader(const std::string &path);
+    std::string getFileExtension(const std::string &path);
     void makeWriteEvent(int &status);
     void makeReadFileEvent(int fd);
 
@@ -30,6 +26,8 @@ class ReadRequestEvent : public AEvent
     int checkRequestStartLine(const LocationBlock &lb);
     int checkRequestHeader(const LocationBlock &lb);
     int checkRequestBody(const LocationBlock &lb);
+
+    void makeCgiEvent(const std::string &lbCgiPath);
 
   public:
     ReadRequestEvent(const Server &server, int clientSocket);

--- a/src/server/HttpStatusInfos.cpp
+++ b/src/server/HttpStatusInfos.cpp
@@ -23,9 +23,9 @@ void HttpStatusInfos::initHttpStatusInfos(char **envp)
 
 void HttpStatusInfos::initMimeType()
 {
-    mMimeType["html"] = "text/html";
-    mMimeType["png"] = "image/png";
-    mMimeType["ico"] = "image/x-icon";
+    mMimeType[".html"] = "text/html";
+    mMimeType[".png"] = "image/png";
+    mMimeType[".ico"] = "image/x-icon";
 }
 
 void HttpStatusInfos::initHttpStatusReasons()
@@ -35,6 +35,7 @@ void HttpStatusInfos::initHttpStatusReasons()
     mHttpStatusReasons[301] = "Moved Permanently";
     mHttpStatusReasons[307] = "Temporary Redirect";
     mHttpStatusReasons[400] = "Bad Request";
+    mHttpStatusReasons[403] = "Forbidden";
     mHttpStatusReasons[404] = "Not Found";
     mHttpStatusReasons[405] = "Method Not Allowed";
     mHttpStatusReasons[413] = "Content Too Large";


### PR DESCRIPTION
### Summary
- 상태코드 enum 추가했습니다.
- ReadRequsetEvent의 handle에 있던 cgi로직을 메소드로 옮겼습니다.
- addMimeTypeHeader()를 getFileExtension()메소드로 분리했습니다.
### Description
#### 상태코드 enum 추가했습니다.
- ReadRequsetEvent 메소드에 매직넘버로 되어있던 상태코드를 enum를 추가하여 교체했습니다.
#### ReadRequsetEvent의 handle에 있던 cgi로직을 메소드로 옮겼습니다.
- makeCgiEvent() 메소드를 만들어서 분리했습니다.
#### addMimeTypeHeader()를 getFileExtension()메소드로 분리했습니다.
- cgi 검사할때 cgi의 확장자와 locationBlock의 cgi_cgi_extension과 동일한지 비교하는 로직이 필요합니다
- cgi의 확장자의 로직이 addMimeTypeHeader내부의 fileExtension만 구하는 로직과 같아서 addMimeTypeHeader의 로직의 일부를 getFileExtension으로 만들었습니다.
- addMimeTypeHeader()은 getFileExtension()으로 확장자를 구한다음  mResponse.addHead("Content-type", HttpStatusInfos::getMimeType(getFileExtension(filePath))); 이런식으로 content-type를 필요한곳에 추가했습니다.
### TODO
- mimeType를 더 추가해야 할 것 같습니다.
- kqueue 타이머 이벤트를 추가 해야 합니다.
