### PR TITLE
[FIX] 400, 403 응답일 때 에러 수정 및 가독성을 위한 리펙토링

### DIFF
--- a/include/event/ReadRequestEvent.hpp
+++ b/include/event/ReadRequestEvent.hpp
@@ -6,6 +6,13 @@
 class ReadRequestEvent : public AEvent
 {
   private:
+    enum eCgiPipe
+    {
+        SERVER_READ = 0,
+        SERVER_WRITE = 3,
+        CGI_READ = 2,
+        CGI_WRITE = 1,
+    };
     Request mRequest;
     std::string mStringBuffer;
     std::string mFilePrefix;
@@ -27,7 +34,7 @@ class ReadRequestEvent : public AEvent
     int checkRequestHeader(const LocationBlock &lb);
     int checkRequestBody(const LocationBlock &lb);
 
-		bool checkCgiEvent(const LocationBlock &lb);
+    bool checkCgiEvent(const LocationBlock &lb);
     void makeCgiEvent(const std::string &lbCgiPath);
 
   public:

--- a/include/event/ReadRequestEvent.hpp
+++ b/include/event/ReadRequestEvent.hpp
@@ -27,6 +27,7 @@ class ReadRequestEvent : public AEvent
     int checkRequestHeader(const LocationBlock &lb);
     int checkRequestBody(const LocationBlock &lb);
 
+		bool checkCgiEvent(const LocationBlock &lb);
     void makeCgiEvent(const std::string &lbCgiPath);
 
   public:

--- a/include/event/ReadRequestEvent.hpp
+++ b/include/event/ReadRequestEvent.hpp
@@ -30,9 +30,9 @@ class ReadRequestEvent : public AEvent
 
     void makeResponse(const LocationBlock &lb, int &status);
     int checkRequestError(const LocationBlock &lb);
-    int checkRequestStartLine(const LocationBlock &lb);
-    int checkRequestHeader(const LocationBlock &lb);
-    int checkRequestBody(const LocationBlock &lb);
+    int checkStartLine(const LocationBlock &lb);
+    int checkHeader(const LocationBlock &lb);
+    int checkBody(const LocationBlock &lb);
 
     bool checkCgiEvent(const LocationBlock &lb);
     void makeCgiEvent(const std::string &lbCgiPath);

--- a/include/event/ReadRequestEvent.hpp
+++ b/include/event/ReadRequestEvent.hpp
@@ -15,13 +15,13 @@ class ReadRequestEvent : public AEvent
     int getErrorPageFd(const LocationBlock &lb, int status);
     int getIndexFd(const LocationBlock &lb, int &stauts);
     int getFileFd(int &status);
-    int getRequestFd(int &status);
+    int getRequestFd(const LocationBlock &lb, int &status);
     void setFilePrefix(const LocationBlock &lb);
     std::string getFileExtension(const std::string &path);
     void makeWriteEvent(int &status);
     void makeReadFileEvent(int fd);
 
-    void makeResponse(int &status);
+    void makeResponse(const LocationBlock &lb, int &status);
     int checkRequestError(const LocationBlock &lb);
     int checkRequestStartLine(const LocationBlock &lb);
     int checkRequestHeader(const LocationBlock &lb);

--- a/include/event/Request.hpp
+++ b/include/event/Request.hpp
@@ -33,7 +33,7 @@ class Request
     {
         START_LINE,
         HEADER,
-        CONTENTS,
+        BODY,
         CHUNKED,
         FINISH,
     };
@@ -65,8 +65,8 @@ class Request
     void storeHeaderLine(const std::string &line);
     void storeHeaderMap(std::string buffer);
 
-    void parseRequestHeader(std::string &buffer);
-    void parseRequestContent(std::string &buffer);
+    void parseHeader(std::string &buffer);
+    void parseBody(std::string &buffer);
     bool checkChunkedData(void);
     void parseChunkedBody(std::string &buffer);
 
@@ -75,7 +75,6 @@ class Request
     Request();
     ~Request();
     bool tryParse(std::string &buffer);
-    // int parseChunkedBody(size_t clientMaxBodySize);
 
     char **getCgiEnvp() const;
     int getStatus() const;

--- a/src/event/ReadRequestEvent.cpp
+++ b/src/event/ReadRequestEvent.cpp
@@ -146,10 +146,9 @@ void ReadRequestEvent::setFilePrefix(const LocationBlock &lb)
     mFilePrefix = HttpStatusInfos::getWebservRoot() + requestPath;
 }
 
-int ReadRequestEvent::getRequestFd(int &status)
+int ReadRequestEvent::getRequestFd(const LocationBlock &lb, int &status)
 {
-    std::string requestPath = mRequest.getPath();
-    const LocationBlock &lb = mServer.getLocationBlockForRequest(mRequest.getHost(), requestPath);
+    const std::string &requestPath = mRequest.getPath();
     setFilePrefix(lb);
 
     int fd;
@@ -212,9 +211,9 @@ void ReadRequestEvent::makeReadFileEvent(int fd)
     Kqueue::addEvent(newEvent);
 }
 
-void ReadRequestEvent::makeResponse(int &status)
+void ReadRequestEvent::makeResponse(const LocationBlock &lb, int &status)
 {
-    int fd = getRequestFd(status);
+    int fd = getRequestFd(lb, status);
     mResponse.setStartLine(status);
     if (status == MOVED_PERMANENTLY)
     {
@@ -384,7 +383,7 @@ void ReadRequestEvent::handle()
         return;
     }
 
-    makeResponse(status);
+    makeResponse(lb, status);
     Kqueue::deleteEvent(mClientSocket, EVFILT_READ);
     delete this;
 }

--- a/src/event/ReadRequestEvent.cpp
+++ b/src/event/ReadRequestEvent.cpp
@@ -377,8 +377,8 @@ void ReadRequestEvent::handle()
         status = checkRequestError(lb);
     }
 
-    const std::string &fileExtension = getFileExtension(mRequest.getPath());
-    if (status == OK && lb.getCgiExtension().empty() == false && lb.getCgiExtension() == fileExtension)
+    if (status == OK && lb.getCgiExtension().empty() == false &&
+        lb.getCgiExtension() == getFileExtension(mRequest.getPath()))
     {
         makeCgiEvent(lb.getCgiPath());
         return;

--- a/src/event/ReadRequestEvent.cpp
+++ b/src/event/ReadRequestEvent.cpp
@@ -239,22 +239,22 @@ int ReadRequestEvent::checkRequestError(const LocationBlock &lb)
 {
     int status;
 
-    if ((status = checkRequestStartLine(lb)) != OK)
+    if ((status = checkStartLine(lb)) != OK)
     {
         return status;
     }
-    else if ((status = checkRequestHeader(lb)) != OK)
+    else if ((status = checkHeader(lb)) != OK)
     {
         return status;
     }
-    else if ((status = checkRequestBody(lb)) != OK)
+    else if ((status = checkBody(lb)) != OK)
     {
         return status;
     }
     return OK;
 }
 
-int ReadRequestEvent::checkRequestStartLine(const LocationBlock &lb)
+int ReadRequestEvent::checkStartLine(const LocationBlock &lb)
 {
     const std::string &method = mRequest.getMethod();
     if (method == "GET" || method == "POST" || method == "DELETE")
@@ -266,7 +266,7 @@ int ReadRequestEvent::checkRequestStartLine(const LocationBlock &lb)
         }
         return OK;
     }
-    else if (method == "HEAD")
+    else if (method == "HEAD" || method == "PUT")
     {
         return NOT_ALLOWED;
     }
@@ -276,7 +276,7 @@ int ReadRequestEvent::checkRequestStartLine(const LocationBlock &lb)
     }
 }
 
-int ReadRequestEvent::checkRequestHeader(const LocationBlock &lb)
+int ReadRequestEvent::checkHeader(const LocationBlock &lb)
 {
     if (!lb.getRedirectionPath().empty())
     {
@@ -290,7 +290,7 @@ int ReadRequestEvent::checkRequestHeader(const LocationBlock &lb)
     return OK;
 }
 
-int ReadRequestEvent::checkRequestBody(const LocationBlock &lb)
+int ReadRequestEvent::checkBody(const LocationBlock &lb)
 {
     if (mRequest.getBody().size() > lb.getClientMaxBodySize())
     {

--- a/src/event/Request.cpp
+++ b/src/event/Request.cpp
@@ -112,7 +112,7 @@ void Request::storeHeaderMap(std::string buffer)
     }
 }
 
-void Request::parseRequestHeader(std::string &buffer)
+void Request::parseHeader(std::string &buffer)
 {
     size_t pos = 0;
     if ((pos = buffer.find(CRLF CRLF)) != std::string::npos)
@@ -144,7 +144,7 @@ void Request::parseRequestHeader(std::string &buffer)
             ss << it->second;
             ss >> mContentLength;
             buffer.erase(0, pos + 4);
-            mRequestLine = CONTENTS;
+            mRequestLine = BODY;
             return;
         }
 
@@ -205,7 +205,7 @@ void Request::parseChunkedBody(std::string &buffer)
     }
 }
 
-void Request::parseRequestContent(std::string &buffer)
+void Request::parseBody(std::string &buffer)
 {
     mBody += buffer;
     buffer = "";
@@ -228,11 +228,11 @@ bool Request::tryParse(std::string &buffer)
     }
     if (mRequestLine == HEADER)
     {
-        parseRequestHeader(buffer);
+        parseHeader(buffer);
     }
-    if (mRequestLine == CONTENTS)
+    if (mRequestLine == BODY)
     {
-        parseRequestContent(buffer);
+        parseBody(buffer);
     }
     if (mRequestLine == CHUNKED)
     {
@@ -243,11 +243,7 @@ bool Request::tryParse(std::string &buffer)
         mConnectionStatus = CONNECTION_CLOSE;
         return true;
     }
-    if (mRequestLine == FINISH)
-    {
-        return true;
-    }
-    return false;
+    return mRequestLine == FINISH;
 }
 
 char **Request::getCgiEnvp() const

--- a/src/server/HttpStatusInfos.cpp
+++ b/src/server/HttpStatusInfos.cpp
@@ -51,6 +51,8 @@ void HttpStatusInfos::initHttpErrorPages()
                            "<center><h1>307 Temporary Redirect</h1></center>" CRLF;
     mHttpErrorPages[400] = "<html>" CRLF "<head><title>400 Bad Request</title></head>" CRLF "<body>" CRLF
                            "<center><h1>400 Bad Request</h1></center>" CRLF;
+    mHttpErrorPages[403] = "<html>" CRLF "<head><title>403 Forbbiden</title></head>" CRLF "<body>" CRLF
+                           "<center><h1>403 Forbidden</h1></center>" CRLF;
     mHttpErrorPages[404] = "<html>" CRLF "<head><title>404 Not Found</title></head>" CRLF "<body>" CRLF
                            "<center><h1>404 Not Found</h1></center>" CRLF;
     mHttpErrorPages[405] = "<html>" CRLF "<head><title>405 Not Allowed</title></head>" CRLF "<body>" CRLF

--- a/src/server/Kqueue.cpp
+++ b/src/server/Kqueue.cpp
@@ -3,7 +3,7 @@
 
 std::vector<struct kevent> Kqueue::mNewEvents;
 int Kqueue::mKq = 0;
-struct kevent Kqueue::mHandleEvents[8];
+struct kevent Kqueue::mHandleEvents[MAX_EVENT_CNT];
 
 void Kqueue::init()
 {
@@ -24,7 +24,7 @@ void Kqueue::addEvent(const struct kevent &event)
 
 void Kqueue::handleEvents()
 {
-    int n = kevent(mKq, &mNewEvents[0], mNewEvents.size(), mHandleEvents, 8, NULL);
+    int n = kevent(mKq, &mNewEvents[0], mNewEvents.size(), mHandleEvents, MAX_EVENT_CNT, NULL);
     if (!mNewEvents.empty())
     {
         mNewEvents.clear();

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -88,7 +88,7 @@ const LocationBlock Server::getLocationBlockForRequest(const std::string &host, 
 
     std::vector<LocationBlock>::const_iterator locIt = targetServerInfo.getLocationBlocks().begin();
 
-    // 지금 location은 길이순으로 정렬이 되어 있는 상태
+    // location은 길이가 긴 것부터 짧은 순으로 정렬이 되어 있는 상태
     for (; locIt != targetServerInfo.getLocationBlocks().end(); ++locIt)
     {
         if (path.find(locIt->getLocationPath()) == 0)


### PR DESCRIPTION
### Summary
- 에러 수정 및 리펙토링 진행했습니다. 작업이 이곳 저곳으로 흩어져 있어요. 커밋을 하나씩 봐주세요.
### Description
- 8e59a7c55c4a1c0097bc6dd211a919696a8605f7 시작줄에 의도적으로 path를 넣지 않을 때 에러가 있어 200일 때만 getFileExtension을 호출하게 했습니다.
- fd5f593bdfdd5b17e580a66a97e34740d6be8adf lb를 두번 불러오는데 인자로 넘겨주고 한번만 불러오게 했습니다.
- d27353aebe0265deda98fbdf8e3d0f0f6765fd10 Request 메소드명이 불필요하게 긴 것 같아서 수정했습니다.
- c1a219f54cebbd2948ddd3937a69e8c171bbabe5 CGI 이벤트를 리펙토링 했습니다. 매직넘버를 enum으로 바꾸고, execve에 인자 넣는 방식을 좀 더 간략하게 바꿨습니다.
- 53f7645ab15cc22b430e8d9d7aff96b3b498c994 가독성을 위해 CGI를 요청하는지 확인하는 조건문을 메소드로 뺐습니다.
- 160ba7afdbf7979cafec3dd9237992d626be94f5 403 에러페이지 만들었습니다. #81 여기도 봐주세요.
- 12bc7653118b40983eeec601df65708ec0385d78 좀 더 명확하게 설명하려고 주석을 추가했습니다.
- b6810ef7fa673287afc44f49edaebbb9bff48e23 #79 에서 이야기 한대로 kqueue 매직넘버 상수화시켰습니다.
