### PR TITLE
[FIX] assert 오타 수정, checkHeader를 checkReturnDirective로 수정

### DIFF
--- a/include/event/ReadRequestEvent.hpp
+++ b/include/event/ReadRequestEvent.hpp
@@ -31,7 +31,7 @@ class ReadRequestEvent : public AEvent
     void makeResponse(const LocationBlock &lb, int &status);
     int checkRequestError(const LocationBlock &lb);
     int checkStartLine(const LocationBlock &lb);
-    int checkHeader(const LocationBlock &lb);
+    int checkReturnDirective(const LocationBlock &lb);
     int checkBody(const LocationBlock &lb);
 
     bool checkCgiEvent(const LocationBlock &lb);

--- a/src/event/ReadRequestEvent.cpp
+++ b/src/event/ReadRequestEvent.cpp
@@ -243,7 +243,7 @@ int ReadRequestEvent::checkRequestError(const LocationBlock &lb)
     {
         return status;
     }
-    else if ((status = checkHeader(lb)) != OK)
+    else if ((status = checkReturnDirective(lb)) != OK)
     {
         return status;
     }
@@ -276,7 +276,7 @@ int ReadRequestEvent::checkStartLine(const LocationBlock &lb)
     }
 }
 
-int ReadRequestEvent::checkHeader(const LocationBlock &lb)
+int ReadRequestEvent::checkReturnDirective(const LocationBlock &lb)
 {
     if (!lb.getRedirectionPath().empty())
     {
@@ -338,7 +338,7 @@ void ReadRequestEvent::makeCgiEvent(const std::string &lbCgiPath)
 
         const std::string &cgiPath = HttpStatusInfos::getWebservRoot() + lbCgiPath;
         const char *cmd[2] = {cgiPath.c_str(), NULL};
-        if (execve(cgiPath.c_str(), const_cast<char *const *>(cmd), mRequest.getCgiEnvp()) == -1)
+        if (execve(cgiPath.c_str(), const_cast<char **const>(cmd), mRequest.getCgiEnvp()) == -1)
         {
             exit(EXIT_FAILURE);
         }

--- a/src/event/ReadRequestEvent.cpp
+++ b/src/event/ReadRequestEvent.cpp
@@ -338,7 +338,7 @@ void ReadRequestEvent::makeCgiEvent(const std::string &lbCgiPath)
 
         const std::string &cgiPath = HttpStatusInfos::getWebservRoot() + lbCgiPath;
         const char *cmd[2] = {cgiPath.c_str(), NULL};
-        if (execve(cgiPath.c_str(), const_cast<char **const>(cmd), mRequest.getCgiEnvp()) == -1)
+        if (execve(cgiPath.c_str(), const_cast<char *const *>(cmd), mRequest.getCgiEnvp()) == -1)
         {
             exit(EXIT_FAILURE);
         }

--- a/src/server/HttpStatusInfos.cpp
+++ b/src/server/HttpStatusInfos.cpp
@@ -152,7 +152,7 @@ const std::string &HttpStatusInfos::getHttpErrorPage(const int statusCode)
     std::map<int, std::string>::const_iterator it;
 
     it = mHttpErrorPages.find(statusCode);
-    assert(it != mHttpStatusReasons.end());
+    assert(it != mHttpErrorPages.end());
     return it->second;
 }
 


### PR DESCRIPTION
### Summary
- assert 오타 수정
- checkHeader를 checkReturnDirective로 수정
### Description
#### assert 오타 수정
- #81 관련해서 assert 조건문이 올바르지 않아서 수정했습니다.
#### checkHeader를 checkReturnDirective로 수정
- checkHeader가 메소드명이 역할과 같지 않아서 checkReturnDirective로 수정했습니다.
### TODO
- 
