### PR TITLE
[FEAT] cgi path error check 추가 했습니다.

### DIFF
--- a/include/event/ReadRequestEvent.hpp
+++ b/include/event/ReadRequestEvent.hpp
@@ -34,7 +34,7 @@ class ReadRequestEvent : public AEvent
     int checkReturnDirective(const LocationBlock &lb);
     int checkBody(const LocationBlock &lb);
 
-    bool checkCgiEvent(const LocationBlock &lb);
+    bool checkCgiEvent(const LocationBlock &lb, int &status);
     void makeCgiEvent(const std::string &lbCgiPath);
 
   public:

--- a/src/event/Request.cpp
+++ b/src/event/Request.cpp
@@ -252,7 +252,7 @@ char **Request::getCgiEnvp() const
     HttpStatusInfos::addEnv("REQUEST_METHOD=" + mMethod);
     HttpStatusInfos::addEnv("SERVER_PROTOCOL=" + mVersion);
     // todo pathInfo가 무엇인지 확인 필요
-    HttpStatusInfos::addEnv("PATH_INFO=/asdf/asdf");
+    HttpStatusInfos::addEnv("PATH_INFO=/");
     MapIt it = mHeaders.begin();
     for (; it != mHeaders.end(); ++it)
     {

--- a/src/event/Request.cpp
+++ b/src/event/Request.cpp
@@ -212,6 +212,7 @@ void Request::parseBody(std::string &buffer)
     if (mBody.size() == mContentLength)
     {
         mStatus = OK;
+        mRequestLine = FINISH;
     }
     // ContentLength보다 더 많이 들어왔을 때
     else if (mBody.size() > mContentLength)
@@ -251,7 +252,7 @@ char **Request::getCgiEnvp() const
     HttpStatusInfos::addEnv("REQUEST_METHOD=" + mMethod);
     HttpStatusInfos::addEnv("SERVER_PROTOCOL=" + mVersion);
     // todo pathInfo가 무엇인지 확인 필요
-    HttpStatusInfos::addEnv("PATH_INFO=/");
+    HttpStatusInfos::addEnv("PATH_INFO=/asdf/asdf");
     MapIt it = mHeaders.begin();
     for (; it != mHeaders.end(); ++it)
     {


### PR DESCRIPTION
### Summary
- ReadRequestEvent클래스의  checkCgi() 메소드 에서 cgiPath에 대한 예외 처리 로직 추가 했습니다. #83 
- chunked가 아니고 contentLength만큼 들어왔을때 mRequestLine = FINISH 추가 했습니다.
### Description
#### ReadRequestEvent클래스의  checkCgi() 메소드 에서 cgiPath에 대한 예외 처리 로직 추가 했습니다.
- access 함수를 통해서 존재하는지, 존재한다면 실행이 가능한지 체크를 합니다
- 없으면 404, 있어도 실행이 불가능하면 403에러를 띄우기 위해서 status의 레퍼런스를 매개변수로 받게 수정했습니다.
#### chunked가 아니고 contentLength만큼 들어왔을때 mRequestLine = FINISH 추가 했습니다.
- 테스트 도중 chunkedData가 아니면 동작이 이상하게 되는 현상(content-length 만큼 넣어줘도 입력을 기다림)이 있었습니다.
- 디버그를 해보니 content-length만큼 들어왔을때  mRequestLine = FINISH 로직이 없어서 인것으로 알아냈습니다.
- mRequestLine = FINISH로직를 추가했습니다.
### TODO
- 
