### PR TITLE
[FEAT] cgi 반환값 처리해서 reponse 시작줄, 헤더에 추가하는 로직을 추가했습니다.

### DIFF
--- a/include/event/ReadCgiEvent.hpp
+++ b/include/event/ReadCgiEvent.hpp
@@ -6,11 +6,13 @@ class ReadCgiEvent : public AEvent
 {
   private:
     int mSocket;
+		bool mIsError;
     std::string mStringBuffer;
     char mBuffer[BUFFER_SIZE];
 
   public:
     ReadCgiEvent(const Server &server, int clientSocket, int socket);
+    bool setReponse(const std::string &line);
     virtual void handle();
 };
 

--- a/include/event/Response.hpp
+++ b/include/event/Response.hpp
@@ -15,6 +15,7 @@ class Response
   public:
     Response();
     void setStartLine(int httpStatusCode);
+    void setStartLine(const std::string &startLine);
     void addHead(const std::string &key, const int value);
     void addHead(const std::string &key, const std::string &value);
     void setBody(const std::string &body);

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -11,5 +11,6 @@ std::string trim(const std::string &str);
 void trimLine(std::string &line);
 void deleteComments(std::string &line);
 void ftGetLine(std::ifstream &file, std::string &line);
+bool caseInsensitiveMatch(const std::string &str1, const std::string &str2);
 
 #endif

--- a/src/event/ReadCgiEvent.cpp
+++ b/src/event/ReadCgiEvent.cpp
@@ -1,12 +1,36 @@
 #include "ReadCgiEvent.hpp"
+#include "HttpStatusInfos.hpp"
 #include "Kqueue.hpp"
 #include "WriteEvent.hpp"
+#include "util.hpp"
 #include <unistd.h>
 
 ReadCgiEvent::ReadCgiEvent(const Server &server, int clientSocket, int socket)
-    : AEvent(server, clientSocket), mSocket(socket)
+    : AEvent(server, clientSocket), mSocket(socket), mIsError(false)
 {
-    mStringBuffer.reserve(100000800);
+}
+
+bool ReadCgiEvent::setReponse(const std::string &line)
+{
+    std::string headerKey;
+    std::string headerVal;
+    size_t pos = line.find(':');
+    if (pos == std::string::npos)
+    {
+        return false;
+    }
+
+    headerKey = line.substr(0, pos);
+    headerVal = trim(line.substr(pos + 1));
+    if (caseInsensitiveMatch(headerKey, "Status") == true)
+    {
+        mResponse.setStartLine(headerVal);
+    }
+    else
+    {
+        mResponse.addHead(headerKey, headerVal);
+    }
+    return true;
 }
 
 void ReadCgiEvent::handle()
@@ -21,13 +45,37 @@ void ReadCgiEvent::handle()
     mStringBuffer.append(mBuffer, n);
     if (n == 0)
     {
-        size_t pos = mStringBuffer.find("\r\n\r\n");
-        mStringBuffer.erase(0, pos + 4);
-        mResponse.setStartLine(200);
-        mResponse.addHead("Content-Length", mStringBuffer.size());
-        mResponse.addHead("Content-Type", "text/html");
-        mResponse.setBody(mStringBuffer);
-
+        size_t pos = mStringBuffer.find("\r\n");
+        if (pos != std::string::npos)
+        {
+            while (pos != 0)
+            {
+                if (setReponse(mStringBuffer.substr(0, pos)) == false)
+                {
+                    mIsError = true;
+                    break;
+                }
+                mStringBuffer.erase(0, pos + 2);
+                pos = mStringBuffer.find("\r\n");
+            }
+            // \r\n\r\n 삭제
+            mStringBuffer.erase(0, pos + 2);
+        }
+        // cgi가 보내준 것 분석했는데 startLine이 없는경우
+        // 500 에러 처리
+        if (mIsError == true || mResponse.getStartLine().empty())
+        {
+            const std::string &errorPage = HttpStatusInfos::getHttpErrorPage(500);
+            mResponse.setStartLine(500);
+            mResponse.addHead("Content-type", "text/html");
+            mResponse.addHead("Content-Length", errorPage.size());
+            mResponse.setBody(errorPage);
+        }
+        else
+        {
+            mResponse.addHead("Content-Length", mStringBuffer.size());
+            mResponse.setBody(mStringBuffer);
+        }
         struct kevent newEvent;
         EV_SET(&newEvent, mClientSocket, EVFILT_WRITE, EV_ADD, 0, 0, new WriteEvent(mServer, mResponse, mClientSocket));
         Kqueue::addEvent(newEvent);

--- a/src/event/Response.cpp
+++ b/src/event/Response.cpp
@@ -13,6 +13,11 @@ void Response::setStartLine(int httpStatusCode)
     mStartLine = oss.str();
 }
 
+void Response::setStartLine(const std::string &startLine)
+{
+    mStartLine = "HTTP/1.1 " + startLine;
+}
+
 void Response::addHead(const std::string &key, const int value)
 {
     std::stringstream ss;

--- a/src/server/HttpStatusInfos.cpp
+++ b/src/server/HttpStatusInfos.cpp
@@ -72,6 +72,7 @@ void HttpStatusInfos::initHttpStatusReasons()
     mHttpStatusReasons[404] = "Not Found";
     mHttpStatusReasons[405] = "Method Not Allowed";
     mHttpStatusReasons[413] = "Content Too Large";
+    mHttpStatusReasons[500] = "Internal Server Error";
     mHttpStatusReasons[501] = "Not Implemented";
     mHttpStatusReasons[503] = "Service Unavailable";
 }
@@ -92,6 +93,8 @@ void HttpStatusInfos::initHttpErrorPages()
                            "<center><h1>405 Not Allowed</h1></center>" CRLF;
     mHttpErrorPages[413] = "<html>" CRLF "<head><title>413 Content Too Large</title></head>" CRLF "<body>" CRLF
                            "<center><h1>413 Content Too Large</h1></center>" CRLF;
+    mHttpErrorPages[500] = "<html> " CRLF "<head><title>500 Internal Server Error</title></head>" CRLF "<body>" CRLF
+                           "<center><h1>500 Internal Server Error</h1></center>" CRLF;
     mHttpErrorPages[501] = "<html>" CRLF "<head><title>501 Not Implemented</title></head>" CRLF "<body>" CRLF
                            "<center><h1>501 Not Implemented</h1></center>" CRLF;
     mHttpErrorPages[503] = "<html>" CRLF "<head><title>503 Service Temporarily Unavailable</title></head>" CRLF

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -55,3 +55,20 @@ void ftGetLine(std::ifstream &file, std::string &line)
     deleteComments(line);
     trimLine(line);
 }
+
+bool caseInsensitiveMatch(const std::string &str1, const std::string &str2)
+{
+    if (str1.size() != str2.size())
+    {
+        return false;
+    }
+
+    for (size_t i = 0; i < str1.size(); ++i)
+    {
+        if (std::tolower(str1[i]) != std::tolower(str2[i]))
+        {
+            return false;
+        }
+    }
+    return true;
+}


### PR DESCRIPTION
### Summary
- cgi 반환값 처리해서 reponse 시작줄, 헤더에 추가하는 로직을 추가했습니다.
- 500에러 추가 및 setStartLine 오버로딩 추가했습니다.
- caseInsensitiveMatch() 대소문자 구분없이 비교하는 메소드 추가했습니다.
### Description
#### cgi 반환값 처리해서 reponse 시작줄, 헤더에 추가하는 로직을 추가했습니다.
- 원래 로직은 cgi 반환값이 어떤 값이든 reponse의 시작줄을 200 ok로 해서 클라이언트 소켓에 보냈습니다.
- 그 로직을 수정해서 \r\n\r\n이 나올때 까지 cgi의 반환값을 해석해서 reponse의 시작줄 및 헤더에 넣어줬습니다.
#### 500에러 추가 및 setStartLine 오버로딩 추가했습니다, caseInsensitiveMatch() 대소문자 구분없이 비교하는 메소드 추가했습니다.
- 만약 cgi의 반환값으로 status를 넣어주지 않았다면 오류로 판단을 했고 500에러를 반환하게 했습니다.
- status: 200 ok 이런식으로 cgi가 반환하기 때문에 string을 받아서 startLine를 만드는 생성자오버로딩을 추가 했습니다.
- status, Status 구분 없이 받기 위해 util에 caseInsensitiveMatch()를 추가했습니다.
### TODO
- 파일업로드 cgi랑 잘 맞는지 확인이 필요합니다.
