### PR TITLE
[FIX] exit 사용금지함수, throw로 변경

### DIFF
--- a/include/event/Request.hpp
+++ b/include/event/Request.hpp
@@ -77,6 +77,7 @@ class Request
     bool tryParse(std::string &buffer);
 
     char **getCgiEnvp() const;
+    void delCgiEnvp(char **cgiEnvp);
     int getStatus() const;
     const std::map<std::string, std::string, CaseInsensitiveCompare> &getHeaders() const;
     const std::string &getHost() const;

--- a/src/event/ReadRequestEvent.cpp
+++ b/src/event/ReadRequestEvent.cpp
@@ -350,20 +350,22 @@ void ReadRequestEvent::makeCgiEvent(const std::string &lbCgiPath)
 
         if (dup2(fd[CGI_READ], STDIN_FILENO) == -1)
         {
-            perror("dup2");
+            throw std::runtime_error("dub2 failed");
         }
         if (dup2(fd[CGI_WRITE], STDOUT_FILENO) == -1)
         {
-            perror("dup22");
+            throw std::runtime_error("execve failed");
         }
         close(fd[2]);
         close(fd[1]);
 
         const std::string &cgiPath = HttpStatusInfos::getWebservRoot() + lbCgiPath;
         const char *cmd[2] = {cgiPath.c_str(), NULL};
-        if (execve(cgiPath.c_str(), const_cast<char *const *>(cmd), mRequest.getCgiEnvp()) == -1)
+        char **cgiEnvp = mRequest.getCgiEnvp();
+        if (execve(cgiPath.c_str(), const_cast<char *const *>(cmd), cgiEnvp) == -1)
         {
-            exit(EXIT_FAILURE);
+            mRequest.delCgiEnvp(cgiEnvp);
+            throw std::runtime_error("execve failed");
         }
     }
     else

--- a/src/event/Request.cpp
+++ b/src/event/Request.cpp
@@ -278,6 +278,15 @@ char **Request::getCgiEnvp() const
     return HttpStatusInfos::allocateNewEnvp();
 }
 
+void Request::delCgiEnvp(char **cgiEnvp)
+{
+    for (int i = 0; cgiEnvp[i]; i++)
+    {
+        delete[] cgiEnvp[i];
+    }
+    delete[] cgiEnvp;
+}
+
 int Request::getStatus() const
 {
     return mStatus;


### PR DESCRIPTION
### Summary
-  execve() exit 부분을 throw로 변경했습니다.
### Description
- exit 함수가 사용 금지여서 main 문에서 처리해서 종료 되도록 만들어진 cgiEnvp를 delete 하고 trhow 합니다
### TODO
- execve()가 실패 리턴되는 케이스 넣어서 테스트 해보기
