### PR TITLE
[Feat] cgi 환경변수를 덧붙이는 로직을 추가했습니다.

### DIFF
--- a/include/event/ReadRequestEvent.hpp
+++ b/include/event/ReadRequestEvent.hpp
@@ -35,7 +35,8 @@ class ReadRequestEvent : public AEvent
     int checkBody(const LocationBlock &lb);
 
     bool checkCgiEvent(const LocationBlock &lb, int &status);
-    void makeCgiEvent(const std::string &lbCgiPath);
+
+    void makeCgiEvent(const LocationBlock &lb);
 
   public:
     ReadRequestEvent(const Server &server, int clientSocket);

--- a/include/event/Request.hpp
+++ b/include/event/Request.hpp
@@ -53,9 +53,9 @@ class Request
     int mStatus;
     eConnectionStatus mConnectionStatus;
     bool mIsChunked;
-
     unsigned long mChunkedSize;
 
+    std::string mPathInfo;
     void checkMethod(std::stringstream &ss);
     void checkPath(std::stringstream &ss);
     void checkHttpVersion(std::stringstream &ss);
@@ -76,7 +76,7 @@ class Request
     ~Request();
     bool tryParse(std::string &buffer);
 
-    char **getCgiEnvp() const;
+    char **getCgiEnvp(const LocationBlock &lb) const;
     int getStatus() const;
     const std::map<std::string, std::string, CaseInsensitiveCompare> &getHeaders() const;
     const std::string &getHost() const;
@@ -84,6 +84,7 @@ class Request
     const std::string &getBody() const;
     const std::string &getMethod() const;
     bool isChunked() const;
+    void setPathInfo(const std::string &pathInfo);
     eConnectionStatus getConnectionStatus() const;
 };
 

--- a/include/parse/BlockBuilder.hpp
+++ b/include/parse/BlockBuilder.hpp
@@ -55,6 +55,7 @@ class BlockBuilder
     bool mIsMethodAllowed;
     std::string mCgiPath;
     std::string mCgiExtension;
+    std::string mCgiUploadDir;
 
     HttpDirective mHttpDirective;
     ServerDirective mServerDirective;

--- a/include/parse/LocationBlock.hpp
+++ b/include/parse/LocationBlock.hpp
@@ -14,11 +14,12 @@ class LocationBlock : public ServerBlock
     bool mIsAllowedDelete;
     std::string mCgiPath;
     std::string mCgiExtension;
+    std::string mCgiUploadDir;
 
   public:
     LocationBlock(const ServerBlock &serverBlock, const std::string &locationPath, bool isAutoIndex, bool isAllowedGet,
-                  bool isAllowedPost, bool isAllowedDelete, const std::string &cgiPath,
-                  const std::string &cgiExtension);
+                  bool isAllowedPost, bool isAllowedDelete, const std::string &cgiPath, const std::string &cgiExtension,
+                  const std::string &cgiUploadDir);
     LocationBlock(const ServerBlock &serverBlock);
     LocationBlock &operator=(const LocationBlock &rhs);
     const std::string &getLocationPath() const;
@@ -28,6 +29,7 @@ class LocationBlock : public ServerBlock
     bool isAllowedDelete() const;
     const std::string &getCgiPath() const;
     const std::string &getCgiExtension() const;
+    const std::string &getCgiUploadDir() const;
     friend std::ostream &operator<<(std::ostream &os, const LocationBlock &locationBlock);
 };
 

--- a/src/event/Request.cpp
+++ b/src/event/Request.cpp
@@ -23,7 +23,7 @@ bool CaseInsensitiveCompare::operator()(const std::string &a, const std::string 
 
 Request::Request()
     : mMethod(""), mPath(""), mVersion(""), mHost(""), mBody(""), mContentLength(0), mRequestLine(START_LINE),
-      mStatus(0), mConnectionStatus(KEEP_ALIVE), mIsChunked(false), mChunkedSize(0)
+      mStatus(0), mConnectionStatus(KEEP_ALIVE), mIsChunked(false), mChunkedSize(0), mPathInfo("/")
 {
 }
 
@@ -247,11 +247,14 @@ bool Request::tryParse(std::string &buffer)
     return mRequestLine == FINISH;
 }
 
-char **Request::getCgiEnvp() const
+char **Request::getCgiEnvp(const LocationBlock &lb) const
 {
+    const std::string &uploadDir = lb.getCgiUploadDir();
     HttpStatusInfos::addCgiEnv("REQUEST_METHOD=" + mMethod);
     HttpStatusInfos::addCgiEnv("SERVER_PROTOCOL=" + mVersion);
-    HttpStatusInfos::addCgiEnv("PATH_INFO=/");
+    HttpStatusInfos::addCgiEnv("UPLOAD_DIR=" + uploadDir);
+    HttpStatusInfos::addCgiEnv("WEBSERV_ROOT=" + HttpStatusInfos::getWebservRoot());
+    HttpStatusInfos::addCgiEnv("PATH_INFO=" + mPathInfo);
 
     MapIt it = mHeaders.begin();
     for (; it != mHeaders.end(); ++it)
@@ -315,4 +318,9 @@ bool Request::isChunked() const
 eConnectionStatus Request::getConnectionStatus() const
 {
     return mConnectionStatus;
+}
+
+void Request::setPathInfo(const std::string &pathInfo)
+{
+    mPathInfo = pathInfo;
 }

--- a/src/parse/BlockBuilder.cpp
+++ b/src/parse/BlockBuilder.cpp
@@ -10,7 +10,7 @@ const std::string BlockBuilder::DEFAULT_SERVER_NAME = "";
 BlockBuilder::BlockBuilder()
     : mRoot(DEFAULT_ROOT), mClientMaxBodySize(E_DEFAULT_CLIENT_BODY_SIZE), mPort(E_DEFAULT_LISTEN_PORT),
       mServerName(DEFAULT_SERVER_NAME), mIsAutoIndex(false), mIsAllowedGet(true), mIsAllowedPost(true),
-      mIsAllowedDelete(true)
+      mIsAllowedDelete(true), mCgiUploadDir("/")
 {
 }
 
@@ -222,6 +222,10 @@ void BlockBuilder::updateConfig(const std::string &key, const std::string &value
     {
         mCgiExtension = value;
     }
+    else if (key == "cgi_upload_dir")
+    {
+        mCgiUploadDir = value;
+    }
     else
     {
         assert(false);
@@ -253,6 +257,7 @@ void BlockBuilder::resetLocationBlockConfig(const ServerBlock &serverBlock)
     mIsAllowedGet = true;
     mIsAllowedPost = true;
     mIsAllowedDelete = true;
+    mCgiUploadDir = "/";
     mErrorCodes.clear();
 }
 
@@ -401,5 +406,5 @@ ServerBlock BlockBuilder::buildServerBlock() const
 LocationBlock BlockBuilder::buildLocationBlock() const
 {
     return LocationBlock(buildServerBlock(), mLocationPath, mIsAutoIndex, mIsAllowedGet, mIsAllowedPost,
-                         mIsAllowedDelete, mCgiPath, mCgiExtension);
+                         mIsAllowedDelete, mCgiPath, mCgiExtension, mCgiUploadDir);
 }

--- a/src/parse/LocationBlock.cpp
+++ b/src/parse/LocationBlock.cpp
@@ -1,14 +1,15 @@
 #include "LocationBlock.hpp"
 LocationBlock::LocationBlock(const ServerBlock &serverBlock, const std::string &locationPath, bool isAutoIndex,
                              bool isAllowedGet, bool isAllowedPost, bool isAllowedDelete, const std::string &cgiPath,
-                             const std::string &cgiExtension)
+                             const std::string &cgiExtension, const std::string &cgiUploadDir)
     : ServerBlock(serverBlock), mLocationPath(locationPath), mIsAutoIndex(isAutoIndex), mIsAllowedGet(isAllowedGet),
-      mIsAllowedPost(isAllowedPost), mIsAllowedDelete(isAllowedDelete), mCgiPath(cgiPath), mCgiExtension(cgiExtension)
+      mIsAllowedPost(isAllowedPost), mIsAllowedDelete(isAllowedDelete), mCgiPath(cgiPath), mCgiExtension(cgiExtension),
+      mCgiUploadDir(cgiUploadDir)
 {
 }
 LocationBlock::LocationBlock(const ServerBlock &serverBlock)
     : ServerBlock(serverBlock), mLocationPath(""), mIsAutoIndex(false), mIsAllowedGet(true), mIsAllowedPost(true),
-      mIsAllowedDelete(true)
+      mIsAllowedDelete(true), mCgiUploadDir("/")
 {
 }
 
@@ -32,6 +33,7 @@ LocationBlock &LocationBlock::operator=(const LocationBlock &rhs)
         mIsAllowedDelete = rhs.mIsAllowedDelete;
         mCgiPath = rhs.mCgiPath;
         mCgiExtension = rhs.mCgiExtension;
+        mCgiUploadDir = rhs.mCgiUploadDir;
     }
     return *this;
 }
@@ -70,6 +72,12 @@ const std::string &LocationBlock::getCgiExtension() const
 {
     return mCgiExtension;
 }
+
+const std::string &LocationBlock::getCgiUploadDir() const
+{
+    return mCgiUploadDir;
+}
+
 std::ostream &operator<<(std::ostream &os, const LocationBlock &locationBlock)
 {
     os << "LocationPath : " << locationBlock.mLocationPath << std::endl;
@@ -105,5 +113,6 @@ std::ostream &operator<<(std::ostream &os, const LocationBlock &locationBlock)
     os << "isAllowedDelete : " << std::boolalpha << locationBlock.mIsAllowedDelete << std::endl;
     os << "cgiPath : " << locationBlock.mCgiPath << std::endl;
     os << "cgiExtension : " << locationBlock.mCgiExtension << std::endl;
+    os << "cgiUploadDir : " << locationBlock.mCgiUploadDir << std::endl;
     return os;
 }

--- a/src/parse/LocationDirective.cpp
+++ b/src/parse/LocationDirective.cpp
@@ -18,4 +18,5 @@ void LocationDirective::initDirectiveMap()
     mDirective["limit_except"] = std::numeric_limits<int>::max();
     mDirective["cgi_extension"] = 1;
     mDirective["cgi_path"] = 1;
+    mDirective["cgi_upload_dir"] = 1;
 }

--- a/www/a.conf
+++ b/www/a.conf
@@ -23,6 +23,7 @@ http {
 	location /python {
 		cgi_extension .py;
 		cgi_path /cgi-bin/upload.py;
+		cgi_upload_dir /www/file/;
 	}
 
 	location /hi 


### PR DESCRIPTION
### Summary
- conf 파일 지시어로 cgi_upload_dir 추가했습니다.
- checkCgiEvent()에서 cgi 확장자 검색하는 로직 및 setPathInfo 하는 로직 추가 했습니다.
- Request클래스에 pathInfo 멤버변수 추가 및 getCgiEnvp() 메소드 내부 환경변수 덧붙이는 로직 추가 했습니다.
- 환경변수 추가 내용은 #93 를 참고바랍니다                                                                                                                                                                                                                                                                                                                                                                                                                        
### Description
#### conf 파일 지시어로 cgi_upload_dir 추가했습니다.
- cgi fileUpload 및 delete 구현 하는 도중 upload_dir의 위치를 지정하면 좋겠다라는 의견이 있었습니다.
- 그 의견에 맞게 conf 파일 지시어로 cgi_upload_dir를 추가했습니다.
- 기본값은 "/" 입니다
#### checkCgiEvent()에서 cgi 확장자 검색하는 로직 및 setPathInfo 하는 로직 추가 했습니다.
- pathInfo를 환경변수로 받음으로써 cgi의 경우 확장자 처리 하는 로직을 변경할 필요가 있습니다.
- 예를 들어서 기존 로직은 /a.bla/abc/def는 확장자를 ""로 처리해서 cgi에 들어가지 않았습니다
- 하지만 pathInfo를 추가함으로써 확장자는 .bla, pathInfo는 /abc/def로 처리해야 합니다.
- 그 로직을 checkCgiEvent에 수정및 추가하였고 자세한 코드의 내용은 gist 확인 부탁드립니다.
#### Request클래스에 pathInfo 멤버변수 추가 및 getCgiEnvp() 메소드 내부 환경변수 덧붙이는 로직 추가 했습니다.
- pathInfo를 ReadRequestEvent::checkCgiEvent()를 처리하는 도중에 알 수 있어서 ReadRequestEvent의 멤버 클래스인 Request클래스에 setPathInfo()로 pathInfo를 set하는 로직를 추가 했습니다.
- pathInfo를 제외한 환경변수들은 
    -  HttpStatusInfos::addCgiEnv("UPLOAD_DIR=" + uploadDir);
    - HttpStatusInfos::addCgiEnv("WEBSERV_ROOT=" + HttpStatusInfos::getWebservRoot());
- 으로 추가했습니다.
### TODO
- delete cgi랑 동작하는지 테스트가 필요합니다.
### GIST
- https://gist.github.com/guune/6f2316d47f912a9f46c334bf2ab93f1d
