### PR TITLE
[FIX] 요청한게 folder일때 folder가 존재하는지 에러 탐색 로직 추가

### DIFF
--- a/src/event/ReadRequestEvent.cpp
+++ b/src/event/ReadRequestEvent.cpp
@@ -48,6 +48,12 @@ int ReadRequestEvent::getIndexFd(const LocationBlock &lb, int &status)
     std::string filePath;
     struct stat fileInfo;
 
+    if (stat(mFilePrefix.c_str(), &fileInfo) == -1 || S_ISDIR(fileInfo.st_mode) == 0)
+    {
+        status = NOT_FOUND;
+        return -1;
+    }
+
     for (; indexIt != indexs.end(); ++indexIt)
     {
         filePath = mFilePrefix + *indexIt;


### PR DESCRIPTION
### Summary
- #99 
- autoIndex 관련 에러가 있어서 수정했습니다.
### Description
#### autoIndex 에러 탐색 로직 추가
- 폴더를 요청한 경우 과거의 로직은 index 파일들이 있는지 확인 없으면 autoIndex가 켜져 있는지 확인를 했습니다.
- 이 과정에서 없는 폴더가 들어온 경우도 autoIndex가 locationBlock에 on 되어 있으면 autoIndex 홈페이지가 켜지는 에러가 있었습니다.
- 그래서 맨 앞에 폴더가 존재하는지 여부를 체크하는 로직을 추가했습니다.
### TODO
- 
