### PR TITLE
[FIX] get mime type에러 수정

### DIFF
--- a/src/server/HttpStatusInfos.cpp
+++ b/src/server/HttpStatusInfos.cpp
@@ -192,7 +192,7 @@ const std::string &HttpStatusInfos::getMimeType(const std::string &type)
 
     if (it == mMimeType.end())
     {
-        return mMimeType[".html"];
+        return mMimeType[".txt"];
     }
     return it->second;
 }

--- a/src/server/HttpStatusInfos.cpp
+++ b/src/server/HttpStatusInfos.cpp
@@ -192,7 +192,7 @@ const std::string &HttpStatusInfos::getMimeType(const std::string &type)
 
     if (it == mMimeType.end())
     {
-        return mMimeType["html"];
+        return mMimeType[".html"];
     }
     return it->second;
 }


### PR DESCRIPTION
### Summary
- mimeType의 기본값이 ""으로 되는 에러가 있어서 수정했습니다.
### Description
#### mimeType의 기본값이 ""으로 되는 에러가 있어서 수정했습니다.
- .html이여야 하는데 html이여서 ""으로 되어서 수정했습니다.
- 기본값이 text/html 이였는데 text/plain으로 수정했습니다.
### TODO
- 
