### PR TITLE
[Fix] X-header 범용적으로 처리했습니다.

### DIFF
--- a/src/event/Request.cpp
+++ b/src/event/Request.cpp
@@ -94,7 +94,7 @@ void Request::storeHeaderLine(const std::string &line)
         mStatus = BAD_REQUEST;
         return;
     }
-    if (headerKey == "X-Secret-Header-For-Test")
+    if (headerKey.find("X-") == 0)
     {
         headerKey = "HTTP_" + headerKey;
     }

--- a/src/server/HttpStatusInfos.cpp
+++ b/src/server/HttpStatusInfos.cpp
@@ -192,7 +192,7 @@ const std::string &HttpStatusInfos::getMimeType(const std::string &type)
 
     if (it == mMimeType.end())
     {
-        return mMimeType[".html"];
+        return mMimeType[".txt"];
     }
     return it->second;
 }

--- a/src/server/HttpStatusInfos.cpp
+++ b/src/server/HttpStatusInfos.cpp
@@ -192,7 +192,7 @@ const std::string &HttpStatusInfos::getMimeType(const std::string &type)
 
     if (it == mMimeType.end())
     {
-        return mMimeType["html"];
+        return mMimeType[".html"];
     }
     return it->second;
 }


### PR DESCRIPTION
### Summary
- X-header 범용적으로 처리했습니다.
### Description
#### X-header 범용적으로 처리했습니다.
- 원래 로직은 X-Secret-Header-For-Test에 맞는 경우만 HTTP_를 앞에 붙여줬습니다.
- 맨앞에 X-가 있는경우에 HTTP_를 붙이는것으로 수정했습니다.
### TODO
- 
