### PR TITLE
[FEAT] 페이지 이동 없이 파일 업로드 가능

### DIFF
--- a/cgi-bin/upload.py
+++ b/cgi-bin/upload.py
@@ -4,41 +4,7 @@
 import os
 import cgi
 
-# 파일 삭제 메소드
-def delete_file():
-    file_info = os.environ.get('PATH_INFO', '')
-    if file_info == '':
-        return 204, "No Content", "<h2>파일 삭제 실패</h2><p>존재하지 않는 파일입니다.</p>"
-    upload_dir = os.environ.get('UPLOAD_DIR', '/')
-    webserv_root = os.environ.get('WEBSERV_ROOT', '')
-    file_path = webserv_root + upload_dir + file_info
-    if os.path.exists(file_path):
-        try:
-            os.remove(file_path)
-            # 삭제 후 파일 목록 출력
-            return 202, "Accepted", "<h2>파일 삭제 성공</h2><p>파일을 삭제하는데 성공했습니다.</p>"
-        except:
-            return 204, "No Content", "<h2>파일 삭제 실패</h2><p>파일을 삭제하는데 실패하였습니다.</p>"
-    else:
-        return 204, "No Content", "<h2>파일 삭제 실패</h2><p>존재하지 않는 파일입니다.</p>"
-
-# 파일 목록 출력
-def print_file_list():
-    upload_dir = os.environ.get('WEBSERV_ROOT', '') + os.environ.get('UPLOAD_DIR', '/')
-    file_list_html = "<ul>"
-    for filename in os.listdir(upload_dir):
-        file_list_html += f'<div><a href="/file/{filename}">{filename}</a>'
-        file_list_html += f'''
-            <form id="deleteForm" method="DELETE" action="python/upload.py/{filename}">
-                <input type="hidden" name="_method" value="DELETE">
-                <input type="submit" value="삭제">
-            </form>
-        </div>
-        '''
-    file_list_html += "</ul>"
-    return file_list_html
-
-# 파일 업로드 함수
+# 파일 업로드 메소드(CGI에서 호출)
 def handle_file_upload():
     form = cgi.FieldStorage()
     
@@ -64,6 +30,41 @@ def handle_file_upload():
     else:
         return 400, "Bad Request", "<h2>파일 업로드 실패</h2><p>파일이 선택되지 않았습니다.</p>"
 
+# 파일 삭제 메소드(CGI에서 호출)
+def delete_file():
+    file_info = os.environ.get('PATH_INFO', '')
+    if file_info == '':
+        return 204, "No Content", "<h2>파일 삭제 실패</h2><p>존재하지 않는 파일입니다.</p>"
+    upload_dir = os.environ.get('UPLOAD_DIR', '/')
+    webserv_root = os.environ.get('WEBSERV_ROOT', '')
+    file_path = webserv_root + upload_dir + file_info
+    if os.path.exists(file_path):
+        try:
+            os.remove(file_path)
+            return 202, "Accepted", "<h2>파일 삭제 성공</h2><p>파일을 삭제하는데 성공했습니다.</p>"
+        except:
+            return 204, "No Content", "<h2>파일 삭제 실패</h2><p>파일을 삭제하는데 실패하였습니다.</p>"
+    else:
+        return 204, "No Content", "<h2>파일 삭제 실패</h2><p>존재하지 않는 파일입니다.</p>"
+
+
+
+# 파일 목록 출력(CGI에서 호출)
+def print_file_list():
+    upload_dir = os.environ.get('WEBSERV_ROOT', '') + os.environ.get('UPLOAD_DIR', '/')
+    file_list_html = "<ul>"
+    for filename in os.listdir(upload_dir):
+        file_list_html += f'<div><a href="/file/{filename}">{filename}</a>'
+        file_list_html += f'''
+            <form id="deleteForm" method="DELETE" action="python/upload.py/{filename}">
+                <input type="hidden" name="_method" value="DELETE">
+                <input type="submit" value="삭제">
+            </form>
+        </div>
+        '''
+    file_list_html += "</ul>"
+    return file_list_html
+
 # HTML 페이지 출력
 def print_html_head():
 		print('''
@@ -77,7 +78,7 @@ def print_html_head():
 								<h1>파일 저장소</h1>
 				''')
 
-# 파일 업로드 함수 호출
+# POST 요청 처리(CGI에서 실행)
 if os.environ['REQUEST_METHOD'] == 'POST':
     status, message, body = handle_file_upload()
     print(f'Status: {status} {message}', end='\r\n')
@@ -86,51 +87,82 @@ if os.environ['REQUEST_METHOD'] == 'POST':
     print(body)
     print('</body></html>')
 
-# 파일 삭제 함수 호출
+# DELETE 요청 처리(CGI에서 실행)
 if os.environ['REQUEST_METHOD'] == 'DELETE':
     status, message, body = delete_file()
     print(f'Status: {status} {message}', end='\r\n')
     print('Content-type: text/html', end='\r\n\r\n')
+    print_html_head()
+    print(body)
+    print('</body></html>')
 
 
-# 파일 목록 출력
+# GET 요청 처리(CGI에서 실행)
 if os.environ['REQUEST_METHOD'] == 'GET':
     print(f'Status: 200 OK', end='\r\n')
     print('Content-type: text/html', end='\r\n\r\n')
     print_html_head()
     print('''
-		<form method="post" enctype="multipart/form-data">
+		<form method="post" enctype="multipart/form-data" >
     <label for="file">업로드할 파일을 선택하세요</label>
     <br>
     <input type="file" name="file" id="file" accept=".txt, .pdf, .docx, .gif, .jpeg">
-    <input type="submit" value="업로드">
+    <input type="submit" value="업로드" onclick="uploadFile()">
 		</form>
 		''')
     print(print_file_list())
-    print('''
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    var deleteForms = document.querySelectorAll('#deleteForm');
-    deleteForms.forEach(function(form) {
-        form.addEventListener('submit', function(event) {
+    
+    # 파일 업로드 기능을 위한 자바스크립트(클라이언트에서 POST 요청을 보내기 위함)
+    upload_js = '''
+				function uploadFile() {
             event.preventDefault();
-            var xhr = new XMLHttpRequest();
-            xhr.open('DELETE', form.action, true);
-            xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
-            xhr.onload = function() {
-                if (xhr.status === 202) {
-                    alert("파일이 성공적으로 삭제되었습니다 😃");
-                    location.reload();
-                } else {
-										alert("파일 삭제에 실패했습니다 😢 ");
+						var file = document.getElementById('file').files[0];
+						if (!file) {
+								alert("파일을 선택하세요 😅");
+                return;
+            }
+            var formData = new FormData();
+            formData.append('file', file);
+						var xhr = new XMLHttpRequest();
+						xhr.open('POST', '/python/upload.py', true);
+						xhr.onload = function() {
+								if (xhr.status === 201) {
+										alert("파일이 성공적으로 업로드되었습니다 🎉");
+										location.reload();
+								} else {
+										alert("파일 업로드에 실패했습니다 😱");
 										location.reload();
 								}
-            };
-            xhr.send('_method=DELETE');
-        });
-    });
-});
-</script>
-''')			
+						};
+						xhr.send(formData);
+				}
+    '''
+
+    # 파일 삭제 기능을 위한 자바스크립트(클라이언트에서 DELETE 요청을 보내기 위함)
+    delete_js = '''
+		document.addEventListener('DOMContentLoaded', function() {
+    		var deleteForms = document.querySelectorAll('#deleteForm');
+    		deleteForms.forEach(function(form) {
+        		form.addEventListener('submit', function(event) {
+            		event.preventDefault();
+            		var xhr = new XMLHttpRequest();
+            		xhr.open('DELETE', form.action, true);
+            		xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+            		xhr.onload = function() {
+                		if (xhr.status === 202) {
+                    		alert("파일이 성공적으로 삭제되었습니다 😃");
+                    		location.reload();
+                		} else {
+												alert("파일 삭제에 실패했습니다 😢 ");
+												location.reload();
+										}
+            		};
+            		xhr.send('_method=DELETE');
+        		});
+    		});
+		});
+		'''
+    
+    print(f'<script>{upload_js}{delete_js}</script>')			
     print('</body></html>')
 

--- a/www/new-year/index.html
+++ b/www/new-year/index.html
@@ -3,8 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<link href="style.css" rel="stylesheet">
-    <link rel="preconnect" href="https://fonts.gstatic.com">
+		<link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Stylish&display=swap" rel="stylesheet">
     <title>Happy New Year</title>
     <style>
@@ -18,11 +17,10 @@
         overflow: hidden;
       }
       .snow {
-        width: 7px;
-        height: 7px;
+        width: 20px;
+        height: 20px;
         opacity: 0;
-        background: #fff;
-        border-radius: 50%;
+        background: none;
         animation: snowFall 10s linear infinite;
       }
       @keyframes snowFall {
@@ -52,57 +50,53 @@
         }
       }
       .snow:nth-of-type(2n) {
-        width: 8px;
-        height: 8px;
         animation-delay: 0s;
         animation-duration: 15s;
-        border: 1px solid #fff;
-        box-shadow: 0 0 10px #fff, 0 0 20px #fff, 0 0 30px #fff, 0 0 40px #fff,
-          0 0 50px #fff;
       }
       .snow:nth-of-type(2n + 1) {
-        animation-delay: 10s;
-        animation-duration: 15s;
-        box-shadow: 0 0 10px #fff, 0 0 20px #fff, 0 0 30px #fff, 0 0 40px #fff,
-          0 0 50px #fff;
-      }
-      .snow:nth-of-type(3n) {
         animation-delay: 5s;
         animation-duration: 15s;
       }
-
       .happy-new-year {
         font-family: "Stylish", sans-serif;
         font-size: 100px;
-        color: #facd05; 
+        color: #facd05;
         text-align: center;
         position: absolute;
-        top: 30%; 
+        top: 30%;
         width: 100%;
       }
-     @media screen and (max-width: 600px) {
-	.happy-new-year {
-		font-size: 50px;
-		top: 30%
-	}
-    }
+      @media screen and (max-width: 600px) {
+        .happy-new-year {
+					font-family: "Stylish", sans-serif;
+          font-size: 35px;
+          top: 30%;
+        }
+      }
     </style>
   </head>
   <body>
     <script>
-      function createSnow() {
+      function createSnow(snow) {
         const el = document.createElement("div");
         el.className = "snow";
+				el.style.left = randomPositon() + "px";
+				el.textContent = snow;
+				el.style.fontSize = "30px";
         el.style.marginLeft = randomPositon() + "px";
         document.body.appendChild(el);
       }
       function randomPositon() {
         return Math.floor(Math.random() * window.innerWidth);
       }
-      for (let i = 0; i < 90; i++) {
-        createSnow();
+      for (let i = 0; i < 300; i++) {
+				createSnow("🎊");
+        createSnow("💰");
+				createSnow("💵");
+				createSnow("🎁");
+				createSnow("🐲");
       }
     </script>
-    <div class="happy-new-year">🐲 새해 복 많이 받으세요 🐲</div>
+    <div class="happy-new-year">🐉 새해 복 많이 받으세요 🐉</div>
   </body>
 </html>


### PR DESCRIPTION
### Summary
- 페이지 이동 없이 파일 업로드 가능하게 했습니다.
### Description
- 기존 form 태그만으로 POST 요청을 보낼 때 브라우저를 새로고침 했을 때 다시 POST 요청을 보내는 문제가 있었습니다. 
- 그래서  DELETE 요청과 마찬가지로 자바스크립트 코드를 추가해서 자바 스크립트에서 POST 요청을 보내고 응답이 오면 페이지를 리로드(GET 요청)해서 POST가 반영된 페이지를 보여줍니다.
- 요청이 자바스크립트 내에서 처리가 됨으로 브라우저에서 새로고침을 했을 때 POST 요청을 다시 보내는 것이 아니라 GET 요청을 보내 POST를 중복해서 보내는 것을 방지했습니다.

<img width="454" alt="스크린샷 2024-01-17 오전 1 31 31" src="https://github.com/gyuseuyunhu/server/assets/114281631/3e15bdb4-5153-4e8d-9da4-c334c5714f34">

`크롬에서 post 요청을 다시 보낼 때 나오는 경고창`


### Gist
- 파이썬 코드는 CGI 프로세스에서 실행되고 자바스크립트 코드는 웹브라우저에서 실행됩니다.
- [파이썬 코드](https://gist.github.com/heehoh/6ac1608af30bbbfe1f2f0b407b7f1f11)
- [자바스크립트 간략 설명](https://gist.github.com/heehoh/37471c151e16a39fbf2ddec3b663f6f3)
