### PR TITLE
[FEAT] timer 이벤트 추가했습니다.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ OBJS_FILES = $(addprefix $(OBJ_DIR)/, $(OBJS)) \
 						 $(addprefix $(OBJ_DIR)/$(SERVER_DIR)/, $(SERVER_OBJS)) \
 
 CXX = c++
-CXXFLAGS = -Wall -Wextra -Werror -std=c++98
+CXXFLAGS = -Wall -Wextra -Werror -std=c++98 -g
 
 all : $(NAME)
 

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ OBJS_FILES = $(addprefix $(OBJ_DIR)/, $(OBJS)) \
 						 $(addprefix $(OBJ_DIR)/$(SERVER_DIR)/, $(SERVER_OBJS)) \
 
 CXX = c++
-CXXFLAGS = -Wall -Wextra -Werror -std=c++98 -g
+CXXFLAGS = -Wall -Wextra -Werror -std=c++98
 
 all : $(NAME)
 

--- a/include/event/AEvent.hpp
+++ b/include/event/AEvent.hpp
@@ -10,9 +10,8 @@ class AEvent
   protected:
     enum
     {
-        ONE_SECOND = 1000000000,
         BUFFER_SIZE = 65536,
-        TIMEOUT_SECONDS = 10,
+        TIMEOUT_SECONDS = 30,
     };
     const Server &mServer;
     Response mResponse;

--- a/include/event/AEvent.hpp
+++ b/include/event/AEvent.hpp
@@ -5,13 +5,15 @@
 #include "Response.hpp"
 #include "Server.hpp"
 
-#define EVENT_FINISH true
-#define EVENT_CONTINUE false
-#define BUFFER_SIZE 65536
-
 class AEvent
 {
   protected:
+    enum
+    {
+        ONE_SECOND = 1000000000,
+        BUFFER_SIZE = 65536,
+        TIMEOUT_SECONDS = 10,
+    };
     const Server &mServer;
     Response mResponse;
     int mClientSocket;
@@ -22,6 +24,7 @@ class AEvent
     AEvent(const Server &server, const Response &response, int clientSocket);
     virtual ~AEvent();
     virtual void handle() = 0;
+    virtual void timer();
 };
 
 #endif

--- a/include/event/ReadCgiEvent.hpp
+++ b/include/event/ReadCgiEvent.hpp
@@ -5,15 +5,16 @@
 class ReadCgiEvent : public AEvent
 {
   private:
-    int mSocket;
-		bool mIsError;
+    int mFd;
+    bool mIsError;
     std::string mStringBuffer;
     char mBuffer[BUFFER_SIZE];
 
   public:
-    ReadCgiEvent(const Server &server, int clientSocket, int socket);
+    ReadCgiEvent(const Server &server, int clientSocket, int fd);
     bool setReponse(const std::string &line);
     virtual void handle();
+    virtual void timer();
 };
 
 #endif

--- a/include/event/ReadFileEvent.hpp
+++ b/include/event/ReadFileEvent.hpp
@@ -16,6 +16,7 @@ class ReadFileEvent : public AEvent
     ReadFileEvent(const Server &server, const Response &response, int clientSocket, int fileFd, int fileSize);
     virtual ~ReadFileEvent();
     virtual void handle();
+    virtual void timer();
 };
 
 #endif

--- a/include/event/ReadRequestEvent.hpp
+++ b/include/event/ReadRequestEvent.hpp
@@ -41,6 +41,7 @@ class ReadRequestEvent : public AEvent
     ReadRequestEvent(const Server &server, int clientSocket);
     virtual ~ReadRequestEvent();
     virtual void handle();
+    virtual void timer();
 };
 
 #endif

--- a/include/event/WriteCgiEvent.hpp
+++ b/include/event/WriteCgiEvent.hpp
@@ -11,12 +11,13 @@ class WriteCgiEvent : public AEvent
     std::string mMessage;
     int mWriteSize;
     int mFileSize;
-    int mSocket;
+    int mFd;
 
   public:
-    WriteCgiEvent(const Server &server, int clientSocket, int socket, std::string message);
+    WriteCgiEvent(const Server &server, int clientSocket, int fd, std::string message);
     virtual ~WriteCgiEvent();
     virtual void handle();
+    virtual void timer();
 };
 
 #endif

--- a/include/server/Kqueue.hpp
+++ b/include/server/Kqueue.hpp
@@ -19,6 +19,7 @@ class Kqueue
     static void handleEvents();
     static void pushAcceptEvent(); // 뺄지 넣을지 고민중
 
+    static bool checkSameIdent(int n, int idx);
     static void deleteEvent(int fd, int filter);
     static void closeKq();
 };

--- a/src/event/AEvent.cpp
+++ b/src/event/AEvent.cpp
@@ -1,4 +1,5 @@
 #include "AEvent.hpp"
+#include <unistd.h>
 
 AEvent::AEvent(const Server &server) : mServer(server)
 {
@@ -14,5 +15,9 @@ AEvent::AEvent(const Server &server, const Response &response, int clientSocket)
 }
 
 AEvent::~AEvent()
+{
+}
+
+void AEvent::timer()
 {
 }

--- a/src/event/AcceptEvent.cpp
+++ b/src/event/AcceptEvent.cpp
@@ -23,6 +23,10 @@ void AcceptEvent::handle()
     }
 
     fcntl(clientSocket, F_SETFL, O_NONBLOCK, FD_CLOEXEC);
-    EV_SET(&newEvent, clientSocket, EVFILT_READ, EV_ADD, 0, 0, new ReadRequestEvent(mServer, clientSocket));
+
+    AEvent *event = new ReadRequestEvent(mServer, clientSocket);
+    EV_SET(&newEvent, clientSocket, EVFILT_READ, EV_ADD, 0, 0, event);
+    Kqueue::addEvent(newEvent);
+    EV_SET(&newEvent, clientSocket, EVFILT_TIMER, EV_ADD | EV_ENABLE, NOTE_SECONDS, TIMEOUT_SECONDS, event);
     Kqueue::addEvent(newEvent);
 }

--- a/src/event/AcceptEvent.cpp
+++ b/src/event/AcceptEvent.cpp
@@ -27,6 +27,6 @@ void AcceptEvent::handle()
     AEvent *event = new ReadRequestEvent(mServer, clientSocket);
     EV_SET(&newEvent, clientSocket, EVFILT_READ, EV_ADD, 0, 0, event);
     Kqueue::addEvent(newEvent);
-    EV_SET(&newEvent, clientSocket, EVFILT_TIMER, EV_ADD | EV_ENABLE, NOTE_SECONDS, TIMEOUT_SECONDS, event);
+    EV_SET(&newEvent, clientSocket, EVFILT_TIMER, EV_ADD, NOTE_SECONDS, TIMEOUT_SECONDS, event);
     Kqueue::addEvent(newEvent);
 }

--- a/src/event/ReadCgiEvent.cpp
+++ b/src/event/ReadCgiEvent.cpp
@@ -38,6 +38,7 @@ void ReadCgiEvent::handle()
     int n = read(mFd, mBuffer, BUFFER_SIZE);
     if (n < 0)
     {
+        Kqueue::deleteEvent(mFd, EVFILT_TIMER);
         close(mFd);
         delete this;
         return;
@@ -87,6 +88,7 @@ void ReadCgiEvent::handle()
         struct kevent newEvent;
         EV_SET(&newEvent, mClientSocket, EVFILT_WRITE, EV_ADD, 0, 0, new WriteEvent(mServer, mResponse, mClientSocket));
         Kqueue::addEvent(newEvent);
+        Kqueue::deleteEvent(mFd, EVFILT_TIMER);
         close(mFd);
 
         delete this;
@@ -104,6 +106,7 @@ void ReadCgiEvent::timer()
     EV_SET(&newEvent, mClientSocket, EVFILT_WRITE, EV_ADD, 0, 0, new WriteEvent(mServer, mResponse, mClientSocket));
     Kqueue::addEvent(newEvent);
 
+    Kqueue::deleteEvent(mFd, EVFILT_TIMER);
     close(mFd);
     delete this;
 }

--- a/src/event/ReadFileEvent.cpp
+++ b/src/event/ReadFileEvent.cpp
@@ -41,8 +41,8 @@ void ReadFileEvent::handle()
 
 void ReadFileEvent::timer()
 {
-    const std::string &errorPage = HttpStatusInfos::getHttpErrorPage(500);
-    mResponse.setStartLine(500);
+    const std::string &errorPage = HttpStatusInfos::getHttpErrorPage(408);
+    mResponse.setStartLine(408);
     mResponse.addHead("Content-type", "text/html");
     mResponse.addHead("Content-Length", errorPage.size());
     mResponse.setBody(errorPage);

--- a/src/event/ReadFileEvent.cpp
+++ b/src/event/ReadFileEvent.cpp
@@ -19,6 +19,7 @@ void ReadFileEvent::handle()
 
     if (n < 0)
     {
+        Kqueue::deleteEvent(mFileFd, EVFILT_TIMER);
         close(mFileFd);
         delete this;
         return;
@@ -27,6 +28,7 @@ void ReadFileEvent::handle()
     mBody.append(mBuffer, n);
     if (mReadSize == mFileSize)
     {
+        Kqueue::deleteEvent(mFileFd, EVFILT_TIMER);
         close(mFileFd);
         mResponse.setBody(mBody);
 
@@ -48,6 +50,7 @@ void ReadFileEvent::timer()
     EV_SET(&newEvent, mClientSocket, EVFILT_WRITE, EV_ADD, 0, 0, new WriteEvent(mServer, mResponse, mClientSocket));
     Kqueue::addEvent(newEvent);
 
+    Kqueue::deleteEvent(mFileFd, EVFILT_TIMER);
     close(mFileFd);
     delete this;
 }

--- a/src/event/ReadFileEvent.cpp
+++ b/src/event/ReadFileEvent.cpp
@@ -36,3 +36,18 @@ void ReadFileEvent::handle()
         delete this;
     }
 }
+
+void ReadFileEvent::timer()
+{
+    const std::string &errorPage = HttpStatusInfos::getHttpErrorPage(500);
+    mResponse.setStartLine(500);
+    mResponse.addHead("Content-type", "text/html");
+    mResponse.addHead("Content-Length", errorPage.size());
+    mResponse.setBody(errorPage);
+    struct kevent newEvent;
+    EV_SET(&newEvent, mClientSocket, EVFILT_WRITE, EV_ADD, 0, 0, new WriteEvent(mServer, mResponse, mClientSocket));
+    Kqueue::addEvent(newEvent);
+
+    close(mFileFd);
+    delete this;
+}

--- a/src/event/ReadRequestEvent.cpp
+++ b/src/event/ReadRequestEvent.cpp
@@ -206,8 +206,10 @@ void ReadRequestEvent::makeReadFileEvent(int fd)
     {
         mResponse.setConnectionClose();
     }
-    EV_SET(&newEvent, mClientSocket, EVFILT_WRITE, EV_ADD, 0, 0,
-           new ReadFileEvent(mServer, mResponse, mClientSocket, fd, mFileSize));
+    AEvent *event = new ReadFileEvent(mServer, mResponse, mClientSocket, fd, mFileSize);
+    EV_SET(&newEvent, fd, EVFILT_READ, EV_ADD, 0, 0, event);
+    Kqueue::addEvent(newEvent);
+    EV_SET(&newEvent, fd, EVFILT_TIMER, EV_ADD | EV_ENABLE, NOTE_SECONDS, TIMEOUT_SECONDS, event);
     Kqueue::addEvent(newEvent);
 }
 
@@ -374,11 +376,16 @@ void ReadRequestEvent::makeCgiEvent(const std::string &lbCgiPath)
         fcntl(fd[SERVER_WRITE], F_SETFL, O_NONBLOCK, FD_CLOEXEC);
 
         struct kevent newEvent;
-        EV_SET(&newEvent, fd[SERVER_WRITE], EVFILT_WRITE, EV_ADD, 0, 0,
-               new WriteCgiEvent(mServer, mClientSocket, fd[SERVER_WRITE], mRequest.getBody()));
+        AEvent *event = new WriteCgiEvent(mServer, mClientSocket, fd[SERVER_WRITE], mRequest.getBody());
+        EV_SET(&newEvent, fd[SERVER_WRITE], EVFILT_WRITE, EV_ADD, 0, 0, event);
         Kqueue::addEvent(newEvent);
-        EV_SET(&newEvent, fd[SERVER_READ], EVFILT_READ, EV_ADD, 0, 0,
-               new ReadCgiEvent(mServer, mClientSocket, fd[SERVER_READ]));
+        EV_SET(&newEvent, fd[SERVER_WRITE], EVFILT_TIMER, EV_ADD | EV_ENABLE, 0, ONE_SECOND, event);
+        Kqueue::addEvent(newEvent);
+
+        event = new ReadCgiEvent(mServer, mClientSocket, fd[SERVER_READ]);
+        EV_SET(&newEvent, fd[SERVER_READ], EVFILT_READ, EV_ADD, 0, 0, event);
+        Kqueue::addEvent(newEvent);
+        EV_SET(&newEvent, fd[SERVER_READ], EVFILT_TIMER, EV_ADD | EV_ENABLE, 0, ONE_SECOND, event);
         Kqueue::addEvent(newEvent);
     }
 }
@@ -410,11 +417,19 @@ void ReadRequestEvent::handle()
     {
         makeCgiEvent(lb.getCgiPath());
         Kqueue::deleteEvent(mClientSocket, EVFILT_READ);
+        Kqueue::deleteEvent(mClientSocket, EVFILT_TIMER);
         delete this;
         return;
     }
 
     makeResponse(lb, status);
     Kqueue::deleteEvent(mClientSocket, EVFILT_READ);
+    Kqueue::deleteEvent(mClientSocket, EVFILT_TIMER);
     delete this;
+}
+
+void ReadRequestEvent::timer()
+{
+    close(mClientSocket);
+    delete (this);
 }

--- a/src/event/WriteCgiEvent.cpp
+++ b/src/event/WriteCgiEvent.cpp
@@ -16,6 +16,7 @@ void WriteCgiEvent::handle()
     int n = write(mFd, mMessage.c_str() + mWriteSize, mMessage.size() - mWriteSize);
     if (n == -1)
     {
+        Kqueue::deleteEvent(mFd, EVFILT_TIMER);
         close(mFd);
         perror("write fail");
         delete this;
@@ -25,6 +26,7 @@ void WriteCgiEvent::handle()
     mWriteSize += n;
     if (mWriteSize == mFileSize)
     {
+        Kqueue::deleteEvent(mFd, EVFILT_TIMER);
         close(mFd);
         delete this;
         return;
@@ -33,6 +35,7 @@ void WriteCgiEvent::handle()
 
 void WriteCgiEvent::timer()
 {
+    Kqueue::deleteEvent(mFd, EVFILT_TIMER);
     close(mFd);
     delete this;
 }

--- a/src/event/WriteEvent.cpp
+++ b/src/event/WriteEvent.cpp
@@ -37,7 +37,10 @@ void WriteEvent::handle()
         }
         Kqueue::deleteEvent(mClientSocket, EVFILT_WRITE);
         struct kevent newEvent;
-        EV_SET(&newEvent, mClientSocket, EVFILT_READ, EV_ADD, 0, 0, new ReadRequestEvent(mServer, mClientSocket));
+        AEvent *event = new ReadRequestEvent(mServer, mClientSocket);
+        EV_SET(&newEvent, mClientSocket, EVFILT_READ, EV_ADD, 0, 0, event);
+        Kqueue::addEvent(newEvent);
+        EV_SET(&newEvent, mClientSocket, EVFILT_TIMER, EV_ADD | EV_ENABLE, NOTE_SECONDS, TIMEOUT_SECONDS, event);
         Kqueue::addEvent(newEvent);
         delete this;
         return;

--- a/src/event/WriteEvent.cpp
+++ b/src/event/WriteEvent.cpp
@@ -40,7 +40,7 @@ void WriteEvent::handle()
         AEvent *event = new ReadRequestEvent(mServer, mClientSocket);
         EV_SET(&newEvent, mClientSocket, EVFILT_READ, EV_ADD, 0, 0, event);
         Kqueue::addEvent(newEvent);
-        EV_SET(&newEvent, mClientSocket, EVFILT_TIMER, EV_ADD | EV_ENABLE, NOTE_SECONDS, TIMEOUT_SECONDS, event);
+        EV_SET(&newEvent, mClientSocket, EVFILT_TIMER, EV_ADD, NOTE_SECONDS, TIMEOUT_SECONDS, event);
         Kqueue::addEvent(newEvent);
         delete this;
         return;

--- a/src/server/HttpStatusInfos.cpp
+++ b/src/server/HttpStatusInfos.cpp
@@ -92,7 +92,7 @@ void HttpStatusInfos::initHttpErrorPages()
                            "<center><h1>404 Not Found</h1></center>" CRLF;
     mHttpErrorPages[405] = "<html>" CRLF "<head><title>405 Not Allowed</title></head>" CRLF "<body>" CRLF
                            "<center><h1>405 Not Allowed</h1></center>" CRLF;
-    mHttpErrorPages[408] = " < html > " CRLF "<head><title>408 Request Time-out</title></head>" CRLF "<body>" CRLF
+    mHttpErrorPages[408] = "<html>" CRLF "<head><title>408 Request Time-out</title></head>" CRLF "<body>" CRLF
                            "<center><h1>408 Request Time-out</h1></center>" CRLF;
     mHttpErrorPages[413] = "<html>" CRLF "<head><title>413 Content Too Large</title></head>" CRLF "<body>" CRLF
                            "<center><h1>413 Content Too Large</h1></center>" CRLF;

--- a/src/server/HttpStatusInfos.cpp
+++ b/src/server/HttpStatusInfos.cpp
@@ -71,6 +71,7 @@ void HttpStatusInfos::initHttpStatusReasons()
     mHttpStatusReasons[403] = "Forbidden";
     mHttpStatusReasons[404] = "Not Found";
     mHttpStatusReasons[405] = "Method Not Allowed";
+    mHttpStatusReasons[408] = "Request Timeout";
     mHttpStatusReasons[413] = "Content Too Large";
     mHttpStatusReasons[500] = "Internal Server Error";
     mHttpStatusReasons[501] = "Not Implemented";
@@ -91,6 +92,8 @@ void HttpStatusInfos::initHttpErrorPages()
                            "<center><h1>404 Not Found</h1></center>" CRLF;
     mHttpErrorPages[405] = "<html>" CRLF "<head><title>405 Not Allowed</title></head>" CRLF "<body>" CRLF
                            "<center><h1>405 Not Allowed</h1></center>" CRLF;
+    mHttpErrorPages[408] = " < html > " CRLF "<head><title>408 Request Time-out</title></head>" CRLF "<body>" CRLF
+                           "<center><h1>408 Request Time-out</h1></center>" CRLF;
     mHttpErrorPages[413] = "<html>" CRLF "<head><title>413 Content Too Large</title></head>" CRLF "<body>" CRLF
                            "<center><h1>413 Content Too Large</h1></center>" CRLF;
     mHttpErrorPages[500] = "<html> " CRLF "<head><title>500 Internal Server Error</title></head>" CRLF "<body>" CRLF


### PR DESCRIPTION
### Summary
- timer 이벤트 추가했습니다. #92 
### Description
#### timer 이벤트 추가했습니다.
##### kqueue::checkSameIdent()
- 타이머랑 동일한 fd를 가진 다른 이벤트(ReadRequestEvent, writeEvent, readFileEvent등)가 kevent에서 반환되면 타이머 이벤트는 continue로 넘기고 다른 이벤트를 실행하는 메소드 입니다.
#### timer가 발생하는 event와 그와 관련된 처리들
##### ReadRequestEvent->timer()
- 클라이언트에서 연결된 후 클라이언트에서 request요청(get 등)이 일정시간동안 없을때 발생합니다.
- timer를 삭제하고 mClientSocket를 close 해줍니다.
##### ReadFileEvent->timer()
- readFileEvent에서 일정시간동안 file을 read를 못하면 발생합니다.
- timer를 삭제하고 408 관련된 response를 생성하고 writeEvent를 생성합니다.
##### WriteCgiEvent->timer()
- cgi에게 write가 일정시간동안 못하면 발생합니다.
- timer를 삭제하고 관련된 파일을 close 합니다.
##### ReadCgiEvent->timer()
- cgi에게 read를 일정시간동안 못하면 발생합니다.
- timer를 삭제하고 500 관련된 response를 생성하고 writeEvent를 생성합니다.
- ### TODO
- ReadFileEvent->timer()에서 타이머가 발생하면 408이 맞는지 검토가 필요합니다.
- ReadRequestEvent->timer()에 에러처리가 올바른지 검토가 필요합니다.
- 지금은 test에 맞게 10초로 설정을 했는데 일정시간에 대한 고민이 필요합니다
