### PR TITLE
[FIX] 부분일치 문제 로직 수정했습니다.

### DIFF
--- a/src/parse/BlockBuilder.cpp
+++ b/src/parse/BlockBuilder.cpp
@@ -205,6 +205,10 @@ void BlockBuilder::updateConfig(const std::string &key, const std::string &value
     else if (key == "path")
     {
         mLocationPath = value;
+        if (mLocationPath[0] != '/')
+        {
+            mLocationPath = '/' + mLocationPath;
+        }
     }
     else if (key == "autoindex")
     {

--- a/src/parse/ServerBlock.cpp
+++ b/src/parse/ServerBlock.cpp
@@ -6,7 +6,6 @@ ServerBlock::ServerBlock(const HttpBlock &httpBlock, unsigned int port, const st
 {
 }
 
-// todo 이게 맞는지 확인 필요
 ServerBlock::ServerBlock(const ServerBlock &other) : HttpBlock(other)
 {
     if (this != &other)

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -87,13 +87,15 @@ const LocationBlock Server::getLocationBlockForRequest(const std::string &host, 
     }
 
     std::vector<LocationBlock>::const_iterator locIt = targetServerInfo.getLocationBlocks().begin();
-
-    // location은 길이가 긴 것부터 짧은 순으로 정렬이 되어 있는 상태
     for (; locIt != targetServerInfo.getLocationBlocks().end(); ++locIt)
     {
         if (path.find(locIt->getLocationPath()) == 0)
         {
-            return *locIt;
+            if (locIt->getLocationPath().size() == 1 || locIt->getLocationPath().size() == path.size() ||
+                path[locIt->getLocationPath().size()] == '/')
+            {
+                return *locIt;
+            }
         }
     }
     return LocationBlock(targetServerInfo.getServerBlock());


### PR DESCRIPTION
### Summary
-  부분일치 문제 로직 수정했습니다.
### Description
####  부분일치 문제 로직 수정했습니다.
-  Server::getLocationBlockForRequest()의     
``` C++
for (; locIt != targetServerInfo.getLocationBlocks().end(); ++locIt)
    {
        if (path.find(locIt->getLocationPath()) == 0)
        {
            return *locIt;
        }
    }
```
- 의 로직에 문제가 있어서 수정했습니다
- 예를 들어서 path가 /directory123.html이고 locIt->getLocationPath()가 /directory, /abc, / 일때
- /directory가 반환되는 문제가 있었습니다.
- 부분일치로직을 포함해서 에러 체크하는 로직을 추가 했습니다.
- 자세한 내용은 gist를 참고바랍니다.
### TODO
-
### GIST
- https://gist.github.com/guune/baadbeb782473f22b2b7a51080db88fc
