### PR TITLE
[HOTFIX] 이모지 글자 길이 문제

### DIFF
--- a/cgi-bin/upload.pl
+++ b/cgi-bin/upload.pl
@@ -199,7 +199,7 @@ print <<HTML;
         <input type="color" id="endColor" name="endColor" value="#090a0f">
         <br><br>
         <label for="emojiInput" >이모지 입력:</label>
-        <input type="text" id="emojiInput" name="emojiInput" size="2" value="❄️" maxLength="2">
+        <input type="text" id="emojiInput" name="emojiInput" size="2" value="❄️">
         <br><br>
         <input type="submit" value="페이지 만들기">
     </form>


### PR DESCRIPTION
### Summary
- 이모지 유니코드 마다 길이가 달라 maxLength 속성을 지웠습니다.
