### PR TITLE
[FIX] mIsAllowedDelete의 기본값을 false로 변경했습니다. filesize가 0일때 로직 수정했습니다.

### DIFF
--- a/src/event/ReadRequestEvent.cpp
+++ b/src/event/ReadRequestEvent.cpp
@@ -212,11 +212,20 @@ void ReadRequestEvent::makeReadFileEvent(int fd)
     {
         mResponse.setConnectionClose();
     }
-    AEvent *event = new ReadFileEvent(mServer, mResponse, mClientSocket, fd, mFileSize);
-    EV_SET(&newEvent, fd, EVFILT_READ, EV_ADD, 0, 0, event);
-    Kqueue::addEvent(newEvent);
-    EV_SET(&newEvent, fd, EVFILT_TIMER, EV_ADD, NOTE_SECONDS, TIMEOUT_SECONDS, event);
-    Kqueue::addEvent(newEvent);
+    if (mFileSize == 0)
+    {
+        close(fd);
+        EV_SET(&newEvent, mClientSocket, EVFILT_WRITE, EV_ADD, 0, 0, new WriteEvent(mServer, mResponse, mClientSocket));
+        Kqueue::addEvent(newEvent);
+    }
+    else
+    {
+        AEvent *event = new ReadFileEvent(mServer, mResponse, mClientSocket, fd, mFileSize);
+        EV_SET(&newEvent, fd, EVFILT_READ, EV_ADD, 0, 0, event);
+        Kqueue::addEvent(newEvent);
+        EV_SET(&newEvent, fd, EVFILT_TIMER, EV_ADD, NOTE_SECONDS, TIMEOUT_SECONDS, event);
+        Kqueue::addEvent(newEvent);
+    }
 }
 
 void ReadRequestEvent::makeResponse(const LocationBlock &lb, int &status)

--- a/src/parse/BlockBuilder.cpp
+++ b/src/parse/BlockBuilder.cpp
@@ -10,7 +10,7 @@ const std::string BlockBuilder::DEFAULT_SERVER_NAME = "";
 BlockBuilder::BlockBuilder()
     : mRoot(DEFAULT_ROOT), mClientMaxBodySize(E_DEFAULT_CLIENT_BODY_SIZE), mPort(E_DEFAULT_LISTEN_PORT),
       mServerName(DEFAULT_SERVER_NAME), mIsAutoIndex(false), mIsAllowedGet(true), mIsAllowedPost(true),
-      mIsAllowedDelete(true), mCgiUploadDir("/")
+      mIsAllowedDelete(false), mCgiUploadDir("/")
 {
 }
 
@@ -260,7 +260,7 @@ void BlockBuilder::resetLocationBlockConfig(const ServerBlock &serverBlock)
     mIsAutoIndex = false;
     mIsAllowedGet = true;
     mIsAllowedPost = true;
-    mIsAllowedDelete = true;
+    mIsAllowedDelete = false;
     mCgiUploadDir = "/";
     mErrorCodes.clear();
 }

--- a/src/parse/LocationBlock.cpp
+++ b/src/parse/LocationBlock.cpp
@@ -9,7 +9,7 @@ LocationBlock::LocationBlock(const ServerBlock &serverBlock, const std::string &
 }
 LocationBlock::LocationBlock(const ServerBlock &serverBlock)
     : ServerBlock(serverBlock), mLocationPath(""), mIsAutoIndex(false), mIsAllowedGet(true), mIsAllowedPost(true),
-      mIsAllowedDelete(true), mCgiUploadDir("/")
+      mIsAllowedDelete(false), mCgiUploadDir("/")
 {
 }
 


### PR DESCRIPTION
### Summary
- mIsAllowedDelete의 기본값을 false로 변경했습니다.
- filesize가 0일때 로직 수정했습니다.
### Description
#### mIsAllowedDelete의 기본값을 false로 변경했습니다.
- 모든곳에서 delete를 허용하는게 보안상 좋지 않을것 같아서 기본값을 false로 바꿨습니다.
#### filesize가 0일때 로직 수정했습니다. 
- 0일때 읽으려고 시도하면 block이 되서 close를 해주고 body가 없이 writeEvent를 호출합니다.
### TODO
- 
